### PR TITLE
Mobile geoeditor configurability

### DIFF
--- a/munimap/helper.py
+++ b/munimap/helper.py
@@ -220,14 +220,12 @@ def load_app_config(config=None, without_404=False):
 
 
 def apply_selectionlists_to_geoeditor(app_config, app_config_path):
-    if app_config.get('components') is None:
+    if app_config.get('geoeditor') is None:
         return
-    if app_config.get('components').get('geoeditor') is None:
-        return
-    if app_config.get('components').get('geoeditor').get('formFields') is None:
+    if app_config.get('geoeditor').get('formFields') is None:
         return
 
-    form_fields = app_config['components']['geoeditor']['formFields']
+    form_fields = app_config['geoeditor']['formFields']
     for geometry_fields in form_fields.values():
         for field in geometry_fields:
             if field['type'] != 'select' or not isinstance(field['select'], str):

--- a/munimap/static/js/base-controller.js
+++ b/munimap/static/js/base-controller.js
@@ -36,10 +36,10 @@ angular.module('munimapBase')
             $scope.menuButtonEnabled = munimapConfig.components.menuButton === true;
             $scope.measureLabelSegmentsEnabled = munimapConfig.components.measureLabelSegments === true;
             $scope.drawEnabled = munimapConfig.components.draw === true;
+            $scope.geoeditorEnabled = munimapConfig.components.geoeditor === true;
 
-            if (angular.isDefined(munimapConfig.components.geoeditor)) {
-                $scope.geoeditorEnabled = true;
-                $scope.geoeditor = munimapConfig.components.geoeditor;
+            if ($scope.geoeditorEnabled) {
+                $scope.geoeditorConfig = munimapConfig.geoeditor;
             }
 
             if ($scope.drawEnabled && $scope.geoeditorEnabled) {

--- a/munimap/static/js/draw-layer-config.js
+++ b/munimap/static/js/draw-layer-config.js
@@ -55,7 +55,7 @@ angular.module('munimapDraw', [
         function(LayersService, DrawService, DefaultStyle, ColorpickerPalette, munimapConfig,
             StyleSchema, StyleSchemaFormOptions, LabelSchema, LabelSchemaFormOptions, DrawIconsPrefix) {
 
-            if(munimapConfig.components.draw !== undefined || munimapConfig.components.geoeditor !== undefined) {
+            if(munimapConfig.components.draw !== undefined || munimapConfig.components.geoeditor === true) {
                 var drawLayer = new anol.layer.Feature({
                     title: 'DrawLayer',
                     name: 'draw_layer',

--- a/munimap/static/js/draw-layer-config.js
+++ b/munimap/static/js/draw-layer-config.js
@@ -55,7 +55,7 @@ angular.module('munimapDraw', [
         function(LayersService, DrawService, DefaultStyle, ColorpickerPalette, munimapConfig,
             StyleSchema, StyleSchemaFormOptions, LabelSchema, LabelSchemaFormOptions, DrawIconsPrefix) {
 
-            if(munimapConfig.components.draw !== undefined || munimapConfig.components.geoeditor === true) {
+            if(!!munimapConfig.components.draw || !!munimapConfig.components.geoeditor) {
                 var drawLayer = new anol.layer.Feature({
                     title: 'DrawLayer',
                     name: 'draw_layer',

--- a/munimap/static/js/geoeditor/geoeditor-draw-controller.js
+++ b/munimap/static/js/geoeditor/geoeditor-draw-controller.js
@@ -5,7 +5,7 @@ angular.module('munimapGeoeditor')
     .controller('geoeditorDrawController', ['$scope', '$rootScope', 'GeoeditorValidationService', 'PostMessageService', 'DrawService', 'MapService', 'munimapConfig', 'DefaultStyle', 'PrintPageService', 'LayersService', 'PrintService',
         function ($scope, $rootScope, GeoeditorValidationService, PostMessageService, DrawService, MapService, munimapConfig, DefaultStyle, PrintPageService, LayersService, PrintService) {
 
-            const geoeditorConfig = munimapConfig.components.geoeditor;
+            const geoeditorConfig = munimapConfig.geoeditor;
             const allowedUrls = geoeditorConfig.allowedUrls;
 
             const missingFeaturesText = 'Some feature types are missing.';

--- a/munimap/static/js/geoeditor/geoeditor-popup-controller.js
+++ b/munimap/static/js/geoeditor/geoeditor-popup-controller.js
@@ -10,7 +10,7 @@ angular.module('munimapGeoeditor')
 
                 let showForm = true;
 
-                if (angular.isUndefined(munimapConfig.components.geoeditor.formFields)) {
+                if (angular.isUndefined(munimapConfig.geoeditor.formFields)) {
                     showForm = false;
                 } else {
                     const geometryType = feature.getGeometry().getType();
@@ -19,7 +19,7 @@ angular.module('munimapGeoeditor')
                         'LineString': 'line',
                         'Polygon': 'polygon'
                     }[geometryType];
-                    const formFields = munimapConfig.components.geoeditor.formFields[type];
+                    const formFields = munimapConfig.geoeditor.formFields[type];
                     if (angular.isUndefined(formFields) || formFields.length === 0) {
                         showForm = false;
                     }
@@ -28,7 +28,7 @@ angular.module('munimapGeoeditor')
                 $scope.showGeoeditorTab = showForm;
 
                 if (!showForm) {
-                    if (!munimapConfig.components.geoeditor.customStyling) {
+                    if (!munimapConfig.geoeditor.customStyling) {
                         return;
                     }
                     $scope.defaultPopupTabContent = undefined;

--- a/munimap/static/js/geoeditor/geoeditor-validation-service.js
+++ b/munimap/static/js/geoeditor/geoeditor-validation-service.js
@@ -111,7 +111,7 @@ function GeoeditorValidationServiceProvider() {
         }
 
         function getFormConfig (feature) {
-            var formFields = munimapConfig.components.geoeditor.formFields;
+            var formFields = munimapConfig.geoeditor.formFields;
             switch (feature.getGeometry().getType()) {
             case 'Point':
                 return formFields.point;
@@ -148,7 +148,7 @@ function GeoeditorValidationServiceProvider() {
         }
 
         function getMissingFeatures() {
-            var geometries = munimapConfig.components.geoeditor.geometries;
+            var geometries = munimapConfig.geoeditor.geometries;
 
             const missing = {
                 point: 0,

--- a/munimap/static/sass/components/_geoeditor.sass
+++ b/munimap/static/sass/components/_geoeditor.sass
@@ -20,7 +20,7 @@
     margin-left: 10px
 
 // if under this map width, switch to the compact layout
-$geoeditor-compact-layout-break: 650px
+$geoeditor-compact-layout-break: 750px
 $geoeditor-remove-texts-break: 350px
 
 @mixin compact-design

--- a/munimap/templates/munimap/app/geoeditor-popup.html
+++ b/munimap/templates/munimap/app/geoeditor-popup.html
@@ -16,7 +16,7 @@
                 <h4 ng-switch-when="marker">{$ _('Marker') $}</h4>
             </div>
             <div class="popup-content">
-                <ul ng-show="geoeditor.customStyling"
+                <ul ng-show="geoeditorConfig.customStyling"
                     class="nav nav-tabs tabs-left">
                     <li ng-show="showGeoeditorTab"
                         ng-class="{'active': popupTabContent === 'geoeditor'}"
@@ -71,9 +71,9 @@
                     <div ng-show="popupTabContent === 'geoeditor'"
                          class="geoeditor">
                         <div anol-feature-form
-                             point-fields="geoeditor.formFields.point"
-                             line-fields="geoeditor.formFields.line"
-                             polygon-fields="geoeditor.formFields.polygon"
+                             point-fields="geoeditorConfig.formFields.point"
+                             line-fields="geoeditorConfig.formFields.line"
+                             polygon-fields="geoeditorConfig.formFields.polygon"
                              feature="feature"
                              highlight-invalid="highlightInvalid"
                              validate="isValid(field, value)">

--- a/munimap/templates/munimap/app/map.html
+++ b/munimap/templates/munimap/app/map.html
@@ -1,11 +1,11 @@
 <div anol-drawer ng-if="geoeditorEnabled">
     <div anol-draw
          template-url="munimap/geoeditor-draw.html"
-         geometries="geoeditor.geometries"
+         geometries="geoeditorConfig.geometries"
          post-draw-action="openGeoeditorPopup(layer, feature)"
          post-delete-action="onDelete(layer, feature)"
          on-modify-select="onModifySelect()"
-         live-measure="geoeditor.displayMeasurements"
+         live-measure="geoeditorConfig.displayMeasurements"
          short-text="true"
     >
     </div>

--- a/munimap/templates/munimap/app/ng-templates/geoeditor-draw.html
+++ b/munimap/templates/munimap/app/ng-templates/geoeditor-draw.html
@@ -12,7 +12,7 @@
                 tooltip-trigger="mouseenter">
             <div class="draw-icon"></div>
             <span class="geoeditor-button-text">
-                {$ _('Draw point') $}
+                {{ geometriesConfig.point.text }}
             </span>
             <span ng-class="['geoeditor-badge', 'badge', geometryCount.point < geometriesConfig.point.min ? 'badge-red' : 'badge-green']">
                 {{ getBadgeText(geometryCount.point, geometriesConfig.point) }}
@@ -29,11 +29,11 @@
                 tooltip-trigger="mouseenter">
             <div class="draw-icon"></div>
             <span class="geoeditor-button-text">
-                    {$ _('Draw line') $}
-                </span>
+                {{ geometriesConfig.line.text }}
+            </span>
             <span ng-class="['geoeditor-badge', 'badge', geometryCount.line < geometriesConfig.line.min ? 'badge-red' : 'badge-green']">
-                    {{ getBadgeText(geometryCount.line, geometriesConfig.line) }}
-                </span>
+                {{ getBadgeText(geometryCount.line, geometriesConfig.line) }}
+            </span>
         </button>
         <button ng-click="drawPolygon()"
                 ng-show="geometriesConfig.polygon.enabled"
@@ -46,11 +46,11 @@
                 tooltip-trigger="mouseenter">
             <div class="draw-icon"></div>
             <span class="geoeditor-button-text">
-                    {$ _('Draw polygon') $}
-                </span>
+                {{ geometriesConfig.polygon.text }}
+            </span>
             <span ng-class="['geoeditor-badge', 'badge', geometryCount.polygon < geometriesConfig.polygon.min ? 'badge-red' : 'badge-green']">
-                    {{ getBadgeText(geometryCount.polygon, geometriesConfig.polygon) }}
-                </span>
+                {{ getBadgeText(geometryCount.polygon, geometriesConfig.polygon) }}
+            </span>
         </button>
     </div>
     <div class="btn-group geoeditor-edit">

--- a/munimap/translations/de/LC_MESSAGES/messages.po
+++ b/munimap/translations/de/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2021-06-29 16:33+0200\n"
+"POT-Creation-Date: 2021-07-01 13:59+0200\n"
 "PO-Revision-Date: 2015-12-11 10:51+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: de\n"
@@ -1103,7 +1103,6 @@ msgid "anol.draw.TOOLTIP_POINT"
 msgstr "Punkt zeichnen"
 
 #: ../munimap/templates/munimap/app/ng-templates/draw.html:12
-#: ../munimap/templates/munimap/app/ng-templates/geoeditor-draw.html:15
 #: ../munimap_digitize/munimap_digitize/templates/digitize/app/ng-templates/draw.html:16
 msgid "Draw point"
 msgstr "Punkt"
@@ -1114,7 +1113,6 @@ msgid "anol.draw.TOOLTIP_LINE"
 msgstr "Linie zeichnen"
 
 #: ../munimap/templates/munimap/app/ng-templates/draw.html:23
-#: ../munimap/templates/munimap/app/ng-templates/geoeditor-draw.html:32
 #: ../munimap_digitize/munimap_digitize/templates/digitize/app/ng-templates/draw.html:27
 msgid "Draw line"
 msgstr "Linie"
@@ -1125,7 +1123,6 @@ msgid "anol.draw.TOOLTIP_POLYGON"
 msgstr "Polygon zeichnen"
 
 #: ../munimap/templates/munimap/app/ng-templates/draw.html:34
-#: ../munimap/templates/munimap/app/ng-templates/geoeditor-draw.html:49
 #: ../munimap_digitize/munimap_digitize/templates/digitize/app/ng-templates/draw.html:38
 msgid "Draw polygon"
 msgstr "Fläche"

--- a/munimap/translations/messages.pot
+++ b/munimap/translations/messages.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2021-06-29 16:33+0200\n"
+"POT-Creation-Date: 2021-07-01 13:59+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1092,7 +1092,6 @@ msgid "anol.draw.TOOLTIP_POINT"
 msgstr ""
 
 #: ../munimap/templates/munimap/app/ng-templates/draw.html:12
-#: ../munimap/templates/munimap/app/ng-templates/geoeditor-draw.html:15
 #: ../munimap_digitize/munimap_digitize/templates/digitize/app/ng-templates/draw.html:16
 msgid "Draw point"
 msgstr ""
@@ -1103,7 +1102,6 @@ msgid "anol.draw.TOOLTIP_LINE"
 msgstr ""
 
 #: ../munimap/templates/munimap/app/ng-templates/draw.html:23
-#: ../munimap/templates/munimap/app/ng-templates/geoeditor-draw.html:32
 #: ../munimap_digitize/munimap_digitize/templates/digitize/app/ng-templates/draw.html:27
 msgid "Draw line"
 msgstr ""
@@ -1114,7 +1112,6 @@ msgid "anol.draw.TOOLTIP_POLYGON"
 msgstr ""
 
 #: ../munimap/templates/munimap/app/ng-templates/draw.html:34
-#: ../munimap/templates/munimap/app/ng-templates/geoeditor-draw.html:49
 #: ../munimap_digitize/munimap_digitize/templates/digitize/app/ng-templates/draw.html:38
 msgid "Draw polygon"
 msgstr ""


### PR DESCRIPTION
Makes geoeditor configurable through default config.

For this the config was moved out of `componentes.geoeditor` to the root. This means that **ALL** applications using geoeditor need to be adjusted accordingly.

```yaml
components:
  geoeditor:
    config: 'value'
```

becomes
```yaml
components:
  geoeditor: true

geoeditor:
  config: 'value'
```