### PR TITLE
Add gpkg-builder container

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -1,4 +1,4 @@
-version: '3.8'
+version: '3'
 services:
   munimap-nginx:
     image: library/nginx:1.21.0-alpine
@@ -8,6 +8,7 @@ services:
       - ./nginx/default.conf:/etc/nginx/conf.d/default.conf
     extra_hosts:
       - host.docker.internal:host-gateway
+
   munimap-postgis:
     image: mdillon/postgis:11-alpine
     ports:
@@ -19,6 +20,7 @@ services:
     volumes:
       - ./postgres/postgresql_init_data:/docker-entrypoint-initdb.d
       - ./postgres/postgresql_data:/var/lib/postgresql/data:Z
+
   munimap-print:
     image: docker.terrestris.de/camptocamp/mapfish_print:3.28@sha256:dd97cd8cfd7212b2e24708d392b9dbff81e7756e29d99d3d08333c88e4597496
     ports:
@@ -26,3 +28,7 @@ services:
     volumes:
       - ./munimap-print/print-apps:/usr/local/tomcat/webapps/ROOT/print-apps:Z
       - ./tmp:/tmp:Z
+
+  munimap-gpkg-builder:
+    build:
+      context: ./gpkg-builder

--- a/docker/gpkg-builder/Dockerfile
+++ b/docker/gpkg-builder/Dockerfile
@@ -1,0 +1,18 @@
+FROM osgeo/gdal:ubuntu-small-3.4.0
+
+RUN apt update && apt install -y \
+    bash \
+    cron
+
+RUN mkdir -p /opt/etc/styles \
+    && touch /opt/etc/styles/make_gpkg.sh \
+    && chmod +x /opt/etc/styles/make_gpkg.sh
+
+# We need a file to watch in order to keep tail running
+RUN mkdir -p /var/log \
+    && touch /var/log/cron.log
+
+COPY ./make_gpkg.cron /tmp/make-gpkg
+RUN crontab < /tmp/make-gpkg
+
+CMD ["/bin/bash", "-c", "chmod 644 /etc/cron.d/make-gpkg && cron && tail -f /var/log/cron.log"]

--- a/docker/gpkg-builder/README.md
+++ b/docker/gpkg-builder/README.md
@@ -1,0 +1,8 @@
+# Docker GPKG-Builder
+
+Creates gpkg files as a cron job.
+
+To actually make the container work, create following mount points:
+
+- `/opt/etc/styles/make-gpkg.sh` - Shell script that actually creates gpkg files
+- output directory, as specified in `make-gpkg.sh`

--- a/docker/gpkg-builder/make_gpkg.cron
+++ b/docker/gpkg-builder/make_gpkg.cron
@@ -1,0 +1,4 @@
+#M  H       D   m   WD   Command
+# update gpkg files 
+5  2      *   *   *    /opt/etc/styles/make_gpkg.sh
+


### PR DESCRIPTION
This adds the `munimap-gpkg-builder` container.

This is basically a gdal image that runs any mounted shell script as a cronjob.