### PR TITLE
reduce bundle size by deduping dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "feiertagejs": "^1.2.2",
     "file-loader": "^6.2.0",
     "html-loader": "^0.5.5",
-    "jquery": "^3.3.1",
+    "jquery": "^3.6.0",
     "jquery-ui": "^1.12.1",
     "ngstorage": "^0.3.11",
     "ol": "^5.2.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -19,6 +19,14 @@ module.exports  = {
         chunkFilename: '[name].bundle.js',
         publicPath: '/',
     },
+    resolve: {
+      alias: {
+        'ol': path.resolve('./node_modules/ol'),
+        'ol-ext': path.resolve('./node_modules/ol-ext'),
+        'bootstrap': path.resolve('./node_modules/bootstrap'),
+        'angular-ui-bootstrap': path.resolve('./node_modules/angular-ui-bootstrap')
+      }
+    },
     module: {
         rules: [
             {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -11,7 +11,7 @@ module.exports  = {
         digitize_admin: './munimap_digitize/munimap_digitize/static/js/static-digitize-app.js',
         admin: './munimap/static/js/admin/admin.js',
         static_app:  './munimap/static/js/static-app.js',
-        vendor: ['angular', 'jquery']
+        vendor: ['angular', 'jquery', 'angular-ui-bootstrap', 'core-js']
     },
     output: {
         filename: '[name].bundle.js',
@@ -24,7 +24,8 @@ module.exports  = {
         'ol': path.resolve('./node_modules/ol'),
         'ol-ext': path.resolve('./node_modules/ol-ext'),
         'bootstrap': path.resolve('./node_modules/bootstrap'),
-        'angular-ui-bootstrap': path.resolve('./node_modules/angular-ui-bootstrap')
+        'angular-ui-bootstrap': path.resolve('./node_modules/angular-ui-bootstrap'),
+        'jquery': path.resolve('./node_modules/jquery')
       }
     },
     module: {


### PR DESCRIPTION
Previously, the bundle size was quite big due to duplicate dependencies between this repo and `anol`.

This MR sets aliases for the biggest dependencies so that webpack only bundles them once.

This reduces the parsed bundle size by ~6mb.