### PR TITLE
avoid redirects when requesting catalog groups

### DIFF
--- a/munimap/views/munimap.py
+++ b/munimap/views/munimap.py
@@ -242,7 +242,7 @@ def gfi_catalog_names(config=None):
         groups=catalog_groups_def,
     )
 
-@munimap.route('/app/<config>/catalog/<_type>/<name>/')
+@munimap.route('/app/<config>/catalog/<_type>/<name>')
 def catalog_layer(config=None, _type=None, name=None):
     if config: 
         project = ProtectedProject.by_name_without_404(config)


### PR DESCRIPTION
By default, flask redirects requests without trailing slash to the same request with trailing slash, when the route definition itself ends with a slash.

This PR avoids the redirect by removing the trailing slash on the route definition for catalog layers/groups.