### PR TITLE
Fix postMessage error in IE11

### DIFF
--- a/munimap/static/js/modules/postmessage-service.js
+++ b/munimap/static/js/modules/postmessage-service.js
@@ -66,7 +66,7 @@ angular.module('munimapBase.postMessage', ['anol.map'])
             };
 
             PostMessage.prototype.sendMessage = function (options, target) {
-                if ($window.opener === null) {
+                if ($window.opener === null || $window.opener === undefined) {
                     $window.parent.postMessage(options, target);
                 } else {
                     $window.opener.postMessage(options, target);


### PR DESCRIPTION
If the application was not opened by another website (e.g. iFrame), `$window.opener` is `undefined` instead of `null` in IE11, which causes a follow-up error. This PR fixes this by adding a check for `undefined`.

https://developer.mozilla.org/en-US/docs/Web/API/Window/opener