### PR TITLE
Preserve layer order for groups in map config

### DIFF
--- a/munimap/helper.py
+++ b/munimap/helper.py
@@ -139,9 +139,20 @@ def layers_allowed_for_user(layers):
             layersToCheck.append(layer)
 
     filteredLayers = check_layers_permission(layersToCheck)
-    allowedLayers = allowedLayers + filteredLayers
 
-    return allowedLayers
+    filteredLayersNames = [layer['name'] for layer in filteredLayers]
+    allowedLayersNames = [layer['name'] for layer in allowedLayers]
+
+    allAllowedLayers = []
+
+    # the original layer order needs to be preserved
+    for layer in layers:
+        if layer['name'] in filteredLayersNames:
+            allAllowedLayers.append(layer)
+        elif layer['name'] in allowedLayersNames:
+            allAllowedLayers.append(layer)
+
+    return allAllowedLayers
 
 
 def merge_yaml_dicts(x, y):

--- a/munimap/views/munimap.py
+++ b/munimap/views/munimap.py
@@ -78,7 +78,7 @@ def list_available_icons():
 
 
 @munimap.route('/')
-@munimap.route('/app/<config>')
+@munimap.route('/app/<config>/')
 def index(config=None):
     if config: 
         project = ProtectedProject.by_name_without_404(config)


### PR DESCRIPTION
This preserves the specified layer order for groups that are listed in a map configuration.

Before, protected layers were put on top of other layers.

Also added trailing slash to `/app/<config>` endpoint.