### PR TITLE
fix draw import

### DIFF
--- a/munimap/static/js/base-controller.js
+++ b/munimap/static/js/base-controller.js
@@ -477,7 +477,7 @@ angular.module('munimapBase')
 
             $scope.extractPermalinkFromImport = function(featureCollection) {
                 if(angular.isDefined(featureCollection.properties) && angular.isDefined(featureCollection.properties.permalink)) {
-                    PermalinkService.setPermalinkParameters(featureCollection.properties.permalink);
+                    PermalinkService.applyPermalinkParameters(featureCollection.properties.permalink);
                 }
                 return featureCollection;
             };


### PR DESCRIPTION
This fixes the draw import by replacing the already removed method `PermalinkService.setPermalinkParameters` with `PermalinkServer.applyPermalinkParameters`