### PR TITLE
share popupUrl between selection and official directive

### DIFF
--- a/munimap/static/js/alkis/official.js
+++ b/munimap/static/js/alkis/official.js
@@ -75,7 +75,11 @@ angular.module('munimapBase.alkisOfficial', ['anol.map', 'munimapBase.alkisServi
                                 // no popup present
                                 return;
                             }
-                            const popupUrl = scope.popupUrl;
+                            // $rootScope.popupUrl will only be used to share
+                            // the url between the selection and the official directive.
+                            // This is also why we reset the value immediately after reading.
+                            const popupUrl = scope.popupUrl || $rootScope.popupUrl;
+                            $rootScope.popupUrl = undefined;
                             if (e.data.action) {
                                 // not an ALKIS message, but a message for the PostMessageService
                                 return;
@@ -101,7 +105,7 @@ angular.module('munimapBase.alkisOfficial', ['anol.map', 'munimapBase.alkisServi
                                     if (angular.isDefined($rootScope.popup)) {
                                         $rootScope.popup.postMessage(
                                             {'bbox': scope.printBboxString},
-                                            scope.popupUrl
+                                            popupUrl
                                         );
                                     }
                                 }

--- a/munimap/static/js/alkis/selection.js
+++ b/munimap/static/js/alkis/selection.js
@@ -321,6 +321,7 @@ angular.module('munimapBase.alkisSelection', ['anol.map', 'ngStorage'])
                                     .then(function(response) {
                                         const loc = $window.location;
                                         const appUrl = loc.origin + loc.pathname;
+                                        $rootScope.popupUrl = response['data']['url'];
                                         $rootScope.popup = $window.open(response['data']['url']+'#'+appUrl, '',
                                             'toolbar=no,location=no, status=no, menubar=no, '+
                                             'scrollbars=yes, resizable=yes, width=500, height=600');
@@ -331,6 +332,9 @@ angular.module('munimapBase.alkisSelection', ['anol.map', 'ngStorage'])
                                 .then(function(response) {
                                     const loc = $window.location;
                                     const appUrl = loc.origin + loc.pathname;
+                                    // $rootScope.popupUrl will only be used to share
+                                    // the url between the selection and the official directive.
+                                    $rootScope.popupUrl = response['data']['url'];
                                     $window.open(response['data']['url']+'#'+appUrl, '',
                                         'toolbar=no,location=no, status=no, menubar=no, '+
                                         'scrollbars=yes, resizable=yes, width=500, height=600');


### PR DESCRIPTION
title says it all...

This prevents popupUrl from being undefined, when called via alkis selection.