### PR TITLE
add transport layers as system layers and fix usage of excludePopupLayers

### DIFF
--- a/munimap_transport/munimap_transport/static/js/layers.js
+++ b/munimap_transport/munimap_transport/static/js/layers.js
@@ -11,6 +11,7 @@ angular.module('munimapBase').config(['LayersServiceProvider', 'stationLayerURL'
     var stationLayer = new anol.layer.BBOXGeoJSON({
         name: 'selectable_stations',
         displayInLayerswitcher: false,
+        isSystem: true,
         minResolution: 3,
         maxResolution: 20,
         featureinfo: {
@@ -36,6 +37,7 @@ angular.module('munimapBase').config(['LayersServiceProvider', 'stationLayerURL'
     var stationPointLayer = new anol.layer.BBOXGeoJSON({
         name: 'selectable_station_points',
         displayInLayerswitcher: false,
+        isSystem: true,
         featureinfo: {
             properties: ['name', 'city', 'routes']
         },
@@ -59,6 +61,7 @@ angular.module('munimapBase').config(['LayersServiceProvider', 'stationLayerURL'
     var routeLayer = new anol.layer.StaticGeoJSON({
         name: 'display_routes',
         displayInLayerswitcher: false,
+        isSystem: true,
         olLayer: {
            style: function(feature, resolution) {
                if (feature !== undefined) {

--- a/munimap_transport/munimap_transport/static/js/transport-controller.js
+++ b/munimap_transport/munimap_transport/static/js/transport-controller.js
@@ -157,7 +157,7 @@ angular.module('munimapBase')
                     stationPointLayer.changeUrl(stationPointLayerURL + layer);
                     updateTimetableDate();
                     $scope.stationPopupLayers = [stationsLayer, stationPointLayer];
-                    $scope.excludePopupLayers.push(...$scope.popupLayers, ...$scope.stationPopupLayers);
+                    $scope.excludePopupLayers.push(...$scope.stationPopupLayers);
                     routeLayer.olLayer.setSource();
                     stationsLayer.setVisible(true);
                     stationPointLayer.setVisible(true);

--- a/munimap_transport/munimap_transport/static/js/transport-controller.js
+++ b/munimap_transport/munimap_transport/static/js/transport-controller.js
@@ -157,7 +157,7 @@ angular.module('munimapBase')
                     stationPointLayer.changeUrl(stationPointLayerURL + layer);
                     updateTimetableDate();
                     $scope.stationPopupLayers = [stationsLayer, stationPointLayer];
-                    $scope.excludePopupLayers = $scope.popupLayers.concat($scope.stationPopupLayers);
+                    $scope.excludePopupLayers.push(...$scope.popupLayers, ...$scope.stationPopupLayers);
                     routeLayer.olLayer.setSource();
                     stationsLayer.setVisible(true);
                     stationPointLayer.setVisible(true);


### PR DESCRIPTION
This fixes the use of excludePopupLayers and thereby the opening of unwanted popups for the transport layers.

This also removes the transport layers from the url by adding them as systemlayers.

depends on https://github.com/terrestris/anol/pull/85