### PR TITLE
update paths to docs folder in github actions

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -13,13 +13,13 @@ jobs:
       - name: Build
         uses: ammaraskar/sphinx-action@master
         with:
-          docs-folder: "docs/"
+          docs-folder: "docker/munimap-docs/"
 
       - name: Add .nojekyll file
-        run: sudo touch docs/build/html/.nojekyll # we need sudo here as we otherwise do not have the permissions to write into the build dir.
+        run: sudo touch docker/munimap-docs/build/html/.nojekyll # we need sudo here as we otherwise do not have the permissions to write into the build dir.
 
       - name: Deploy 🚀
         uses: JamesIves/github-pages-deploy-action@v4.2.3
         with:
           branch: gh-pages
-          folder: docs/build/html
+          folder: docker/munimap-docs/build/html


### PR DESCRIPTION
This should fix the pipeline for updating gh-pages by adjusting the path to the docs folder.