### PR TITLE
fix: fix parsing of XML in SVG export

### DIFF
--- a/munimap/svg/mapserv.py
+++ b/munimap/svg/mapserv.py
@@ -1,7 +1,7 @@
 import re
 import sys
 
-from xml.etree.ElementTree import parse
+from xml.etree.ElementTree import fromstring
 from itertools import groupby
 from contextlib import closing
 
@@ -15,13 +15,12 @@ def get_wms_layer_names(base_url, params={}):
     params['REQUEST'] = 'GetCapabilities'
     params['SERVICE'] = 'WMS'
     with closing(requests.get(base_url, params=params, stream=True)) as r:
-        for layer in parse_layer_names(r.raw):
+        for layer in parse_layer_names(r.content):
             yield layer
 
 
 def parse_layer_names(f):
-    tree = parse(f)
-    root = tree.getroot()
+    root = fromstring(f)
 
     for elem in root.findall(
         './wms:Capability/wms:Layer/wms:Layer/wms:Name',


### PR DESCRIPTION
This fixes the SVG Export.

![munimap-svg-export-fix](https://github.com/stadt-bielefeld/bielefeldGEOCLIENT/assets/12186477/f8965b05-799f-442f-9b22-2a7f46c54254)
