### PR TITLE
fix: export street index

### DIFF
--- a/munimap/export/mapfish.py
+++ b/munimap/export/mapfish.py
@@ -511,7 +511,7 @@ def mapfish_printqueue_worker(job):
                 'error': f'unable to request index from {index_url}',
                 'full_error': f'{r}\n{r.content.decode()}',
             }
-        zip_buf.writestr('index.pdf', r.content.decode())
+        zip_buf.writestr('index.pdf', r.content)
 
     zip_buf.write(map_filename, 'map' + ext)
     zip_buf.close()

--- a/munimap/index/pdf.py
+++ b/munimap/index/pdf.py
@@ -220,7 +220,7 @@ class DottedEntry(Paragraph):
             text_width = stringWidth(self.text, self.style.fontName,
                                      self.style.fontSize, self.encoding)
             lines = [(max_width - text_width, [self.text])]
-        return ParaLines(kind=0, fontSize=font_size, fontName=font_name,
+        return ParaLines(kind=0, fontSize=font_size, fontName=font_name, us_lines=False,
                          textColor=self.style.textColor, ascent=font_size,
                          descent=-0.2 * font_size, lines=lines,
                          underline=False, link=False, strike=False, endDots=False)
@@ -266,7 +266,7 @@ class DottedEntry(Paragraph):
 
 
 def create_index_pdf(data, title=None, columns=2):
-    pdf_buffer = io.StringIO()
+    pdf_buffer = io.BytesIO()
 
     styles = getSampleStyleSheet()
 
@@ -339,7 +339,6 @@ def create_index_pdf(data, title=None, columns=2):
 
     doc.build(entries, columns=columns)
 
-    pdf_buffer.reset()
     return pdf_buffer
 
 if __name__ == '__main__':

--- a/munimap/views/vector.py
+++ b/munimap/views/vector.py
@@ -53,7 +53,7 @@ def index_pdf():
     fc = query_feature_collection(req, current_app.pg_layers)
     index = features_to_index_data(fc, current_app.pg_layers)
     return Response(
-        create_index_pdf(index, 'Index', columns=3),
+        create_index_pdf(index, 'Index', columns=3).getvalue(),
         mimetype='application/pdf',
     )
 


### PR DESCRIPTION
This fixes exporting the street index when printing.

![munimap-street-export-fix](https://github.com/stadt-bielefeld/bielefeldGEOCLIENT/assets/12186477/56349050-8c04-42cb-8880-579742c35504)
