### PR TITLE
feat: log layer stats

### DIFF
--- a/munimap/config.py
+++ b/munimap/config.py
@@ -21,6 +21,12 @@ class DefaultConfig(object):
 
     LOG_DIR = '/opt/log/munimap'
 
+    LOG_STATS = False
+    LOG_STATS_FILENAME = '/opt/log/munimap/stats.log'
+    LOG_STATS_MAX_BYTES = 1000000  # 1MB
+    LOG_STATS_BACKUP_COUNT = 5
+    LOG_STATS_WHITELIST = ['http://localhost/mapproxy', 'http://localhost/cgi-bin/mapserv']
+
     # TODO Check if this acutally applies
     ALLOW_UPLOAD_CONFIG = ['127.0.0.1']
     API_PRODUCTION_URL = 'http://localhost:8080'

--- a/munimap/stats/__init__.py
+++ b/munimap/stats/__init__.py
@@ -1,0 +1,1 @@
+from .stats import log_stats

--- a/munimap/stats/stats.py
+++ b/munimap/stats/stats.py
@@ -1,0 +1,59 @@
+import logging
+
+from urllib3.util import parse_url
+from flask import current_app
+
+log = logging.getLogger('munimap.stats')
+
+
+def log_stats(url, req, res, user):
+    """ Log the stat.
+    """
+    should_log_stat = _should_log_stat(url, current_app.config.get('LOG_STATS_WHITELIST', []))
+    if not should_log_stat:
+        return
+    user_name = user.mb_user_name
+    user_department = user.mb_user_department
+
+    referrer = req.referrer
+    ip = req.remote_addr
+    host = req.host
+    user_agent = req.user_agent.string
+
+    app = _get_app_from_url(referrer, current_app.url_map)
+
+    status_code = res.status_code
+    content_length = res.content_length
+
+    msg = f'USER:{user_name} DEPARTMENT:{user_department} APP:{app} IP:{ip} URL:{url} STATUS:{status_code} ' \
+          f'CONTENT-LENGTH:{content_length} HOST:{host} REFERER:{referrer} USER-AGENT:{user_agent}'
+    log.info(msg)
+
+
+def _get_app_from_url(url, url_map):
+    """ Get the app name from the provided URL.
+
+    Returns the name of the app or '/' for the default app
+    that runs under root. Returns None if provided URL does
+    not match the URLs of munimap.index.
+    """
+    parsed_url = parse_url(url)
+    path = parsed_url.path
+    try:
+        adapter = url_map.bind('localhost')
+        method, arg = adapter.match(path)
+        if method != 'munimap.index':
+            return None
+        return arg.get('config', '/')
+    except:
+        return None
+
+
+def _should_log_stat(url, accepted_urls):
+    """ Check if stat should be logged.
+
+    Returns True if provided URL starts with
+    at least one URL from the list of accepted URLs.
+    Returns False otherwise.
+    """
+    return any([url.startswith(u) for u in accepted_urls])


### PR DESCRIPTION
This adds custom logging for layer stats.

- logs stats into dedicated log file
- configurable log rotation
- configurable whitelist of URLs to log stats for

Example log:

```
DATE:2023-07-27 13:21:44,852 USER:my-user DEPARTMENT:my-department APP:my-app IP:172.0.0.10 URL:http://localhost/mapproxy/wmts/my-layer/utm32_adv/8/107/107.png STATUS:200 CONTENT-LENGTH:115119 HOST:localhost REFERER:http://localhost/app/my-app/ USER-AGENT:Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36 
```