### PR TITLE
feat: log stats for catalog endpoints

### DIFF
--- a/munimap/config.py
+++ b/munimap/config.py
@@ -25,7 +25,7 @@ class DefaultConfig(object):
     LOG_STATS_FILENAME = '/opt/log/munimap/stats.log'
     LOG_STATS_MAX_BYTES = 1000000  # 1MB
     LOG_STATS_BACKUP_COUNT = 5
-    LOG_STATS_WHITELIST = ['http://localhost/mapproxy']
+    LOG_STATS_WHITELIST = ['http://localhost']
 
     # TODO Check if this acutally applies
     ALLOW_UPLOAD_CONFIG = ['127.0.0.1']

--- a/munimap/stats/stats.py
+++ b/munimap/stats/stats.py
@@ -1,3 +1,4 @@
+import functools
 import logging
 
 from urllib3.util import parse_url
@@ -6,15 +7,43 @@ from flask import current_app
 log = logging.getLogger('munimap.stats')
 
 
-def log_stats(url, req, res, user):
+def log_stats(request, current_user, use_referrer=False, route_name='munimap.index', app_attr='config', url_from_response=False):
+    """ Decorator for logging stats.
+
+    Can be used for decorating functions that work with request and response objects (e.g. flask routes).
+    Stats will be logged AFTER the decorated function was called.
+
+    Arguments:
+        - `use_referrer`: True, if the referrer URL should be used to derive the application name. False, otherwise.
+        - `route_name`: name of the application route incl. the blueprint prefix, e.g. 'munimap.index'. This will
+            be used to derive the app name from the route.
+        - `app_attr`: The attribute name of the route that contains the application name.
+        - `url_from_response`: True, if the URL should be taken from the request object that is attached to the
+            response object. This can be useful for logging requests that were send by application code. E.g. the
+            request after resolving the URL hash on the /proxy endpoints.
+    """
+    def dec_log_stats(func):
+        @functools.wraps(func)
+        def wrapper_log_stats(*args, **kwargs):
+            res = func(*args, **kwargs)
+            url = request.url
+            if url_from_response:
+                url = res.request.url
+            _log_stats(url, request, res, current_user, use_referrer, route_name, app_attr)
+            return res
+        return wrapper_log_stats
+    return dec_log_stats
+
+
+def _log_stats(url, req, res, user, use_referrer, route_name, app_attr):
     """ Log the stat.
     """
     url_in_whitelist = _is_url_in_whitelist(url, current_app.config.get('LOG_STATS_WHITELIST', []))
     if not url_in_whitelist:
         return
 
-    user_name = 'guest'
-    user_department = 'guest'
+    user_name = None
+    user_department = None
     if not user.is_anonymous:
         user_name = user.mb_user_name
         user_department = user.mb_user_department
@@ -29,31 +58,44 @@ def log_stats(url, req, res, user):
     host = req.host if hasattr(req, 'host') else None
     user_agent = req.user_agent.string if hasattr(req, 'user_agent') else None
 
-    app = _get_app_from_url(referrer, current_app.url_map)
+    if use_referrer:
+        app = _get_app_from_url(referrer, current_app.url_map, route_name, app_attr)
+    else:
+        app = _get_app_from_url(req.base_url, current_app.url_map, route_name, app_attr)
 
     status_code = res.status_code if hasattr(res, 'status_code') else None
     content_length = res.content_length if hasattr(res, 'content_length') else None
+
+    user_name = user_name if user_name else ''
+    user_department = user_department if user_department else ''
+    app = app if app else ''
+    ip = ip if ip else ''
+    url = url if url else ''
+    status_code = status_code if status_code else ''
+    host = host if host else ''
+    referrer = referrer if referrer else ''
+    user_agent = user_agent if user_agent else ''
 
     msg = f'{user_name};{user_department};{app};{ip};{url};{status_code};' \
           f'{content_length};{host};{referrer};{user_agent}'
     log.info(msg)
 
 
-def _get_app_from_url(url, url_map):
+def _get_app_from_url(url, url_map, route_name, app_attr):
     """ Get the app name from the provided URL.
 
     Returns the name of the app or '/' for the default app
     that runs under root. Returns None if provided URL does
-    not match the URLs of munimap.index.
+    not match the URLs of route_name.
     """
     parsed_url = parse_url(url)
     path = parsed_url.path
     try:
         adapter = url_map.bind('localhost')
         method, arg = adapter.match(path)
-        if method != 'munimap.index':
-            return None
-        return arg.get('config', '/')
+        if method and method == route_name:
+            return arg.get(app_attr, '/')
+        return None
     except:
         return None
 


### PR DESCRIPTION
This logs the stats for the apps and catalog endpoints. This also modifies the stat-logging approach by using a decorator (`@log_stats`) instead of calling the logger within the function. This also replaces `None` values in the logs with empty strings, which leads to more compact log lines.

I had to minimally refactor the `wmts_proxy` logic for easier handling of the logger.