### PR TITLE
feat: add /digitize/admin/migrations endpoint

### DIFF
--- a/munimap_digitize/munimap_digitize/views/admin.py
+++ b/munimap_digitize/munimap_digitize/views/admin.py
@@ -55,6 +55,7 @@ def layer_migrations():
         layer_dict = {
             'name': digitize_layer.name,
             'title': digitize_layer.title,
+            'type': 'digitize',
             'source': {
                 'name': digitize_layer.name,
                 'srs': 'EPSG:25832',

--- a/munimap_digitize/munimap_digitize/views/admin.py
+++ b/munimap_digitize/munimap_digitize/views/admin.py
@@ -51,12 +51,14 @@ def layer_migrations():
     layer_dicts = []
     for digitize_layer in digitize_layers:
         digitize_props = digitize_layer.properties_schema.get('properties', {})
+        geom_types = {f['geometry']['type'] for f in digitize_layer.features}
         props = [{'name': prop, 'type': 'text', 'label': val['title']} for prop, val in digitize_props.items()]
         layer_dict = {
             'name': digitize_layer.name,
             'title': digitize_layer.title,
             'type': 'digitize',
             'source': {
+                'geom_type': ','.join(geom_types),
                 'name': digitize_layer.name,
                 'srs': 'EPSG:25832',
                 'properties': props

--- a/munimap_digitize/munimap_digitize/views/admin.py
+++ b/munimap_digitize/munimap_digitize/views/admin.py
@@ -62,7 +62,7 @@ def layer_migrations():
             }
         }
         if digitize_layer.style is not None:
-            layer_dict['source']['style'] = digitize_layer.style
+            layer_dict['style'] = digitize_layer.style
         layer_dicts.append(layer_dict)
 
     yaml_layers = yaml.dump({'layers': layer_dicts})

--- a/munimap_digitize/munimap_digitize/views/admin.py
+++ b/munimap_digitize/munimap_digitize/views/admin.py
@@ -32,13 +32,13 @@ digitize_admin = Blueprint(
 
 @digitize_admin.before_request
 def check_permission():
-    access_allowed = check_group_permission(
-        [current_app.config.get('DIGITIZE_ADMIN_PERMISSION')]
-    )
     if current_user.is_anonymous:
         flash(_('You are not allowed to administrate the digitize layers'),
               'error')
         return redirect(url_for('user.login', next=LocalProxyRequest.url))
+    access_allowed = check_group_permission(
+        [current_app.config.get('DIGITIZE_ADMIN_PERMISSION')]
+    )
     if not access_allowed:
         if LocalProxyRequest.is_xhr:
             return jsonify(message='Not allowed')


### PR DESCRIPTION
This adds the endpoint `/digitize/admin/migrations`, which lists the new yaml format for the digitize layers. This endpoint can be used to put the currently existing digitize layers into any layer yaml.

Please note: Due to the previous layer allowing multiple geometry types per featurecollection, there might be layers with multiple `geom_type`s. These have to be resolved to a single type in order to properly work in the future. Multiple values were only added in order to indicate layers with geometries of multiple types.

Example output:

```
layers:
- name: test_layer
  source:
    name: test_layer
    geom_type: LineString,Point
    properties:
    - label: Baustelle
      name: name
      type: text
    - label: Beschreibung
      name: description
      type: text
    srs: EPSG:25832
  style:
    fillColor: '#fff'
    fillOpacity: 0.4
    fontColor: '#333'
    fontSize: 10px
    fontWeight: normal
    radius: 5
    strokeColor: '#8529cc'
    strokeDashstyle: solid
    strokeOpacity: 1.0
    strokeWidth: 2
  title: Baustellen
  type: digitize
```

Please also note that layers of type `digitize` found in a yaml in `map-configs` have to be removed or adjusted, to fit the new structure.