### PR TITLE
feat(geoeditor): flatten properties of exported geojson

### DIFF
--- a/docker/munimap-docs/source/default-config.rst
+++ b/docker/munimap-docs/source/default-config.rst
@@ -660,7 +660,7 @@ Suche nach Orten über Apache Solr.
           resultMarkerVisible: 0
           urlMarkerColor: E2001A
           autoSearchChars: 3
-          resultMarker: 
+          resultMarker:
               graphicFile: 'geocoder-marker.svg'
               graphicWidth: 32
               graphicHeight: 50
@@ -690,7 +690,7 @@ Suche nach Orten über den Kunden eigenen Catalog-Dienst.
         geocoder: Catalog
         selected: false
         geocoderOptions:
-            steps: 
+            steps:
               - getgemarkungen
               - getflure
               - getflurstuecke
@@ -705,7 +705,7 @@ Suche nach Orten über den Kunden eigenen Catalog-Dienst.
         resultMarkerVisible: 0
         urlMarkerColor: E2001A
         autoSearchChars: 1
-        resultMarker: 
+        resultMarker:
             graphicFile: 'geocoder-marker.svg'
             graphicWidth: 32
             graphicHeight: 50
@@ -1000,7 +1000,7 @@ In diesem Abschnitt werden die Konfigurationen des geoEDITOR-Moduls vorgestellt.
 
         ``geoJSON``
           geoJSON Objekt, welches die gezeichneten Geometrien in EPSG:4326 enthält. Die eingetragenen Formulardaten
-          sind der jeweiligen Geometrie unter dem Attribut ``properties.formValues`` angehängt. Der Style der jeweiligen
+          sind der jeweiligen Geometrie unter dem Attribut ``properties`` angehängt. Der Style der jeweiligen
           Geometrie ist unter dem Attribut ``properties.style`` angehängt.
 
         Bei erfolgloser Validierung antwortet die Schnittstelle mit einem ``finishGeoEditing_response`` Event, welches

--- a/munimap/static/js/geoeditor/geoeditor-draw-controller.js
+++ b/munimap/static/js/geoeditor/geoeditor-draw-controller.js
@@ -41,6 +41,18 @@ angular.module('munimapGeoeditor')
 
                     const geoJSON = geoJSONFormat.writeFeaturesObject(DrawService.activeLayer.getFeatures());
 
+                    // flatten form values
+                    for (const geoJSONFeature of geoJSON.features) {
+                        const {
+                            formValues,
+                            ...otherProps
+                        } = geoJSONFeature.properties;
+                        geoJSONFeature.properties = {
+                            ...formValues,
+                            ...otherProps
+                        };
+                    }
+
                     callback({
                         action: 'finishGeoEditing_response',
                         value: {
@@ -150,7 +162,7 @@ angular.module('munimapGeoeditor')
                     }
                 );
             });
-          
+
             $scope.$parent.$parent.openGeoeditorPopup = function (layer, feature) {
                   if (angular.isUndefined(feature.get('style'))) {
                       var style = angular.copy(DefaultStyle);
@@ -171,7 +183,7 @@ angular.module('munimapGeoeditor')
               // This following event is used to trigger an update of the popup configuration
               // when clicking on an existing geographic element on the map.
               // Without this event the popup element will show the configuration of the last
-              // created element, i.e, it can show tabs for content that should be shown, like the attribute form, 
+              // created element, i.e, it can show tabs for content that should be shown, like the attribute form,
               // even when there are no attributes present.
               $olOn(MapService.getMap(), 'singleclick', (evt) => {
                 MapService.getMap().forEachFeatureAtPixel(evt.pixel, function(feature, layer) {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "directories": {
     "doc": "docs"
   },
+  "engines": {
+    "node": "<17"
+  },
   "scripts": {
     "build": "webpack --mode production",
     "start": "webpack --watch --mode development"


### PR DESCRIPTION
This flattens the properties in the exported geojson of the geoeditor.