### PR TITLE
fix: add NP check to map singleclick event for digitize-popup

### DIFF
--- a/munimap/static/js/digitize/digitize-controller.js
+++ b/munimap/static/js/digitize/digitize-controller.js
@@ -58,8 +58,8 @@ angular.module('munimapDigitize')
                     layerFilter: candidate => candidate === $scope.drawLayer.olLayer,
                     hitTolerance: 10
                 })
-                .filter(f => f.get('_digitizeState') !== DigitizeState.REMOVED);
-                if (features.length > 0) {
+                ?.filter(f => f.get('_digitizeState') !== DigitizeState.REMOVED);
+                if (features && features.length > 0) {
                     $scope.$parent.$parent.openDigitizePopup(features[0]);
                 }
             });


### PR DESCRIPTION
This adds a missing NP check for the click event that opens the digitize-popup