### PR TITLE
fix: fix handling of digitize feature popup

### DIFF
--- a/munimap/static/js/digitize/digitize-popup-controller.js
+++ b/munimap/static/js/digitize/digitize-popup-controller.js
@@ -8,15 +8,21 @@ angular.module('munimapDigitize')
             $scope.featureFilter = featureFilter;
             $scope.needsRefresh = false;
             $scope.openDigitizePopupFor = undefined;
-            $scope.lastOpenedPopup = undefined;
+            $scope.featureEditorProps = {};
             $scope.formFields = undefined;
+            $scope.closePopup = () => {
+                $scope.openDigitizePopupFor = {
+                    coordinate: undefined
+                };
+                $scope.featureEditorProps = {};
+            };
 
             $scope.$on('digitize:openPopupFor', function (event, layer, feature) {
                 $scope.openDigitizePopupFor = {
                     layer: layer.olLayer,
                     feature: feature
                 };
-                $scope.lastOpenedPopup = {
+                $scope.featureEditorProps = {
                     layer: layer,
                     feature: feature
                 };
@@ -24,18 +30,15 @@ angular.module('munimapDigitize')
             });
 
             $scope.$on('digitize:closePopup', function () {
-                $scope.openDigitizePopupFor = {
-                    coordinate: undefined
-                };
-                $scope.lastOpenedPopup = undefined;
+                $scope.closePopup();
             });
 
             $scope.$on('SaveManagerService:polling', (evt, data) => {
-                if ($scope.lastOpenedPopup === undefined) {
+                if (Object.keys($scope.featureEditorProps).length === 0) {
                     return;
                 }
-                const layerName = $scope.lastOpenedPopup.layer.name;
-                const feature = $scope.lastOpenedPopup.feature;
+                const layerName = $scope.featureEditorProps.layer.name;
+                const feature = $scope.featureEditorProps.feature;
                 if (data.layerName !== layerName) {
                     return;
                 }
@@ -43,7 +46,7 @@ angular.module('munimapDigitize')
                     return;
                 }
                 if (data.success) {
-                    $scope.needsRefresh = SaveManagerService.hasFeaturePollingChanges(feature.getId(), $scope.lastOpenedPopup.layer);
+                    $scope.needsRefresh = SaveManagerService.hasFeaturePollingChanges(feature.getId(), $scope.featureEditorProps.layer);
                 } else {
                     $scope.needsRefresh = false;
                 }

--- a/munimap/templates/munimap/app/digitize-popup.html
+++ b/munimap/templates/munimap/app/digitize-popup.html
@@ -10,17 +10,18 @@
          alt-mobile-fullscreen="true"
          feature-filter="featureFilter(feature)"
     >
-        <div ng-controller="popupController">
+        <div>
             <div class="popup-header">
               <h4>{$ _('Properties') $}</h4>
             </div>
             <div class="popup-content">
                 <div class="tab-content">
                     <div class="digitize">
-                        <div anol-feature-properties-editor="feature"
-                            layer="layer"
-                            template-url="munimap/feature-properties-editor.html">
-                        </div>
+                        <div
+                            anol-feature-properties-editor="featureEditorProps.feature"
+                            layer="featureEditorProps.layer"
+                            template-url="munimap/feature-properties-editor.html"
+                        ></div>
                     </div>
                 </div>
             </div>
@@ -31,7 +32,7 @@
                 </div>
                 <div class="action-buttons">
                   <button class="btn btn-default btn-sm"
-                          ng-click="popup.close()">
+                          ng-click="closePopup()">
                       {$ _('Close') $}
                   </button>
                 </div>


### PR DESCRIPTION
In a previous change, popups for newly created features did not show any content. The content was shown only, when opening the popup twice.

This fixes this behaviour. As part of that, I also removed the `ng-controller="popupController"` from the digitize popup, since this references the draw-popup-controller.

Now, we should have a clean and isolated behavior for our popup.

![munimap-digitize-popup-fix](https://github.com/stadt-bielefeld/bielefeldGEOCLIENT/assets/12186477/5b7a4b7c-d6c1-437c-9442-92a9cbc3fd8e)
