### PR TITLE
fix: import german translations for colorpicker

### DIFF
--- a/munimap/static/js/base-controller.js
+++ b/munimap/static/js/base-controller.js
@@ -1,6 +1,7 @@
 require('angular-ui-bootstrap');
 require('bootstrap-tour');
 import 'spectrum-colorpicker/spectrum';
+import 'spectrum-colorpicker/i18n/jquery.spectrum-de';
 
 import {TOUCH as hasTouch} from 'ol/has';
 import {transformExtent, transform} from 'ol/proj';


### PR DESCRIPTION
This adds the German translation for the color picker

![image](https://github.com/stadt-bielefeld/bielefeldGEOCLIENT/assets/12186477/ed50f934-7d1b-4a72-a5d4-388dfefa2612)
