### PR TITLE
fix: refactor datepicker and harmonize geoeditor

### DIFF
--- a/docker/munimap-docs/source/default-config.rst
+++ b/docker/munimap-docs/source/default-config.rst
@@ -950,7 +950,8 @@ In diesem Abschnitt werden die Konfigurationen des geoEDITOR-Moduls vorgestellt.
       Wenn kein Label angegeben ist, wird der ``name`` des Feldes verwendet.
 
     ``type``
-      Der Datentyp des Datenfelds. Erlaubte Werte sind `"text"` für Texte, `"int"` für ganze Zahlen, `"float"` für Dezimalzahlen und `"select"` für Auswahllisten.
+      Der Datentyp des Datenfelds. Erlaubte Werte sind `"text"` für Texte, `"int"` für ganze Zahlen, `"float"` für Dezimalzahlen,
+      `"boolean"` für boolesche Werte, `"date"` für Datumseinträge und `"select"` für Auswahllisten.
 
     ``select``
       Enthält die Auswahllistenkonfiguration. Dieser Wert wird nur berücksichtigt, wenn als ``type`` `"select"` angegeben wurde.

--- a/munimap/static/js/base-config.js
+++ b/munimap/static/js/base-config.js
@@ -13,6 +13,7 @@ require('anol/src/modules/attribution/attribution-directive.js');
 require('anol/src/modules/catalog/catalog-directive.js');
 require('anol/src/modules/catalog/catalog-service.js');
 
+require('anol/src/modules/datepicker/datepicker-directive.js');
 require('anol/src/modules/featurepopup/dragpopup-directive.js');
 require('anol/src/modules/draw/draw-directive.js');
 require('anol/src/modules/draw/draw-service.js');

--- a/munimap/static/js/geoeditor/geoeditor-popup-controller.js
+++ b/munimap/static/js/geoeditor/geoeditor-popup-controller.js
@@ -7,7 +7,7 @@ angular.module('munimapGeoeditor')
             $scope.$on('geoeditor:openPopupFor', function (event, layer, feature) {
                 // in case we are opening an already existent element, check if the feature has formValues. 
                 // If not, then initialize it as an empty object
-                feature.set('formValues', feature.get('formValues') || {})
+                feature.set('formValues', feature.get('formValues') || {});
 
                 let showForm = true;
 

--- a/munimap/static/js/modules/datepicker.js
+++ b/munimap/static/js/modules/datepicker.js
@@ -5,7 +5,7 @@ angular.module('schemaForm').run(['$templateCache',
     function($templateCache) {
         $templateCache.put(
             'directives/decorators/bootstrap/datepicker/datepicker.html',
-            '<div ng-controller="datepickerController" class="form-group munimap-datepicker" ng-class="{\'has-error\': hasError()}"><div class="input-group"> <label class="control-label" ng-show="showTitle()">{{form.title}}</label> <input type="text" class="form-control" sf-field-model="replaceAll" uib-datepicker-popup="{{format}}" datepicker-append-to-body="true" clear-text="Leeren" close-text="Schließen" current-text="Heute" ng-model="dt" datepicker-options="datepickerOptions" is-open="datepickerOpen"/> <span class="input-group-btn"> <button type="button" class="btn btn-default" ng-click="openDatepicker()"> <i class="glyphicon glyphicon-calendar"></i> </button> </span> </div> </div>'
+            '<div class="form-group munimap-datepicker" ng-class="{\'has-error\': hasError()}"><label class="control-label" ng-show="showTitle()">{{form.title}}</label><div class="input-group"><anol-date-picker class="anol-date-picker" date="$$value$$" /></div></div>'
         );
     }
 ]);
@@ -15,7 +15,7 @@ angular.module('schemaForm').config(
         function(schemaFormProvider,  schemaFormDecoratorsProvider, sfPathProvider) {
 
             var datepicker = function(name, schema, options) {
-                if (schema.type === 'string' && schema.format == 'date') {
+                if (schema.type === 'string' && schema.format === 'date') {
                     var f = schemaFormProvider.stdFormObj(name, schema, options);
                     f.key  = options.path;
                     f.type = 'datepicker';
@@ -32,27 +32,3 @@ angular.module('schemaForm').config(
             schemaFormDecoratorsProvider.createDirective('datepicker',
                 'directives/decorators/bootstrap/datepicker/datepicker.html');
         }]);
-
-angular.module('schemaForm')
-    .controller('datepickerController', ['$scope', function($scope) {
-        $scope.datepickerOpen = false;
-        $scope.format = 'dd.MM.yyyy';
-        $scope.openDatepicker = function () {
-          $scope.datepickerOpen = true;
-        }
-
-        var dt = $scope.model[$scope.form.key[0]];
-        $scope.dt = dt ? new Date(dt) : undefined;
-
-        $scope.datepickerOptions = {
-          showWeeks: false,
-          ngModelOptions: {
-            timezone: 'UTC'
-          }
-        };
-        $scope.$watch('dt', function(newValue, _, scope) {
-          if (newValue) {
-            scope.model[scope.form.key[0]] = newValue.toISOString();
-          }
-        });
-    }]);

--- a/munimap/static/js/munimap-config.js
+++ b/munimap/static/js/munimap-config.js
@@ -4,6 +4,7 @@ import GeoJSON from 'ol/format/GeoJSON';
 
 angular.module('munimap', [
     'schemaForm',
+    'anol.datepicker',
     'anol.geolocation',
     'anol.getfeatureinfo',
     'anol.measure',

--- a/munimap/static/sass/components/_geoeditor.sass
+++ b/munimap/static/sass/components/_geoeditor.sass
@@ -23,6 +23,10 @@
     outline: none
     box-shadow: none
 
+.anol-featureform-checkbox
+    width: unset
+    height: unset
+
 // if under this map width, switch to the compact layout
 $geoeditor-compact-layout-break: 750px
 $geoeditor-remove-texts-break: 350px

--- a/munimap/static/sass/digitize.sass
+++ b/munimap/static/sass/digitize.sass
@@ -138,8 +138,8 @@
           position: relative
 
           .munimap-datepicker
-            span.input-group-btn
-              vertical-align: bottom
+            .anol-date-picker
+                display: table
 
           .properties
             .form-horizontal


### PR DESCRIPTION
This updates the datepicker plugin and makes use of the anol datepicker introduced in https://github.com/jansule/anol/pull/12.

This also fixes the css for the geoditor form checkbox.