### PR TITLE
fix: hide refresh layer button after refreshing

### DIFF
--- a/munimap/static/js/digitize/digitize-controller.js
+++ b/munimap/static/js/digitize/digitize-controller.js
@@ -71,7 +71,17 @@ angular.module('munimapDigitize')
                 $rootScope.$broadcast('digitize:closePopup');
             };
 
-            $scope.$on('SaveManagerService:polling', (evt, data) => {
+            const onPollingSuccess = function () {
+                $scope.needsRefresh = SaveManagerService.hasPollingChanges(DrawService.activeLayer);
+                $scope.showPollingError = false;
+            };
+
+            const onPollingError = function () {
+                $scope.needsRefresh = false;
+                $scope.showPollingError = true;
+            };
+
+            const handleSaveManagerEvt = (evt, data) => {
                 if (data.layerName !== $scope.drawLayer.name) {
                     return;
                 }
@@ -80,17 +90,11 @@ angular.module('munimapDigitize')
                 } else {
                     onPollingError();
                 }
-            });
-
-            var onPollingSuccess = function () {
-                $scope.needsRefresh = SaveManagerService.hasPollingChanges(DrawService.activeLayer);
-                $scope.showPollingError = false;
             };
 
-            var onPollingError = function () {
-                $scope.needsRefresh = false;
-                $scope.showPollingError = true;
-            };
+            $scope.$on('SaveManagerService:polling', handleSaveManagerEvt);
+
+            $scope.$on('SaveManagerService:refreshLayer', handleSaveManagerEvt);
 
             $scope.$watch(function () {
                 return DrawService.activeLayer;

--- a/munimap/static/js/digitize/digitize-popup-controller.js
+++ b/munimap/static/js/digitize/digitize-popup-controller.js
@@ -33,7 +33,7 @@ angular.module('munimapDigitize')
                 $scope.closePopup();
             });
 
-            $scope.$on('SaveManagerService:polling', (evt, data) => {
+            const handleSaveManagerEvt = (evt, data) => {
                 if (Object.keys($scope.featureEditorProps).length === 0) {
                     return;
                 }
@@ -50,5 +50,9 @@ angular.module('munimapDigitize')
                 } else {
                     $scope.needsRefresh = false;
                 }
-            });
+            };
+
+            $scope.$on('SaveManagerService:polling', handleSaveManagerEvt);
+
+            $scope.$on('SaveManagerService:refreshLayer', handleSaveManagerEvt);
         }]);


### PR DESCRIPTION
This hides the refresh layer button after refreshing a layer instead of hiding it after the next polling.

depends on https://github.com/terrestris/anol/pull/99

![munimap-digitize-hide-refresh](https://github.com/stadt-bielefeld/bielefeldGEOCLIENT/assets/12186477/985ad39a-f448-43d3-98bc-cbde7bded018)
