### PR TITLE
feat: add contextmenu integration

### DIFF
--- a/docker/munimap-docs/source/default-config.rst
+++ b/docker/munimap-docs/source/default-config.rst
@@ -98,7 +98,7 @@ Im Nachfolgenden werden die Konfigurationsattribute zum grundlegenden Verhalten 
     Ermöglicht eine App die auf eine externe Anwendung verlinkt. Als Wert muss der Link zur Zielseite angegeben werden.
 
   ``contextMenu``
-    Wenn aktiviert, wird durch Rechtsklick das Kontextmenü aktiviert. Es kann der Name (ohne Pfad) der zu nutzenden Datei angegeben werden oder `true` (dann wird `index.html` verwendet). Standardwert `false`. Weitere Details im :ref:`Abschnitt Kontextmenü <context_menu>`.
+    Wenn aktiviert, wird durch Rechtsklick das Kontextmenü aktiviert. Es kann der Name (ohne Pfad und ohne Dateiendung) der zu nutzenden Datei angegeben werden oder `true` (dann wird `index.js` verwendet). Standardwert `false`. Weitere Details im :ref:`Abschnitt Kontextmenü <context_menu>`.
 
 
   ``showLogin``
@@ -861,26 +861,32 @@ Um ALKIS-Dienste nutzen zu können, müssen die IP Syscon ALKIS-Dienste vorliege
 Kontextmenü
 -----------
 
-Das Kontextmenü wird ein einem eigenen Template definiert, das über die Konfigurationsoption `contextMenu` gesteuert wird. Es wird nur angezeigt, wenn die Komponente aktiviert ist. Alle Einträge die in der Variable ``contextmenuItems`` enthalten sind, werden angezeigt.
+Das Kontextmenü wird ein einem eigenen Template definiert, das über die Konfigurationsoption `contextMenu` gesteuert wird.
+Es wird nur angezeigt, wenn die Komponente aktiviert ist. Für jedes Kontextmenü ist eine eigene JavaScript-Datei (.js)
+anzulegen. Das Kontextmenü wird innerhalb dieser als `Immediately Invoked Function Expression (IIFE) <https://developer.mozilla.org/en-US/docs/Glossary/IIFE>`_ definiert.
 
 
 Beispiel::
 
-  let contextmenuItems = [{
-      text: 'Starte OpenStreetMap',
-      title: 'Startet OpenStreetMap an dieser Koordinate',
-      link: true,
-      callback: startOSM
-    }
-  ];
+  (function() {
+    let contextmenuItems = [{
+        text: 'Starte OpenStreetMap',
+        title: 'Startet OpenStreetMap an dieser Koordinate',
+        link: true,
+        callback: startOSM
+      }
+    ];
 
-  function startOSM(obj) {
-    let zoom = obj['zoom'] + 4
-    let url = 'https://www.openstreetmap.org/#map=' + zoom +
-      '/' + obj['coordinates']['EPSG:4326'][1] +
-      '/' + obj['coordinates']['EPSG:4326'][0]
-    return url;
-  }
+    function startOSM(obj) {
+      let zoom = obj['zoom'] + 4
+      let url = 'https://www.openstreetmap.org/#map=' + zoom +
+        '/' + obj['coordinates']['EPSG:4326'][1] +
+        '/' + obj['coordinates']['EPSG:4326'][0]
+      return url;
+    }
+
+    angular.module('munimap').value('ContextMenuItems', contextmenuItems);
+  })();
 
 
 geoeditorConfig

--- a/munimap/config.py
+++ b/munimap/config.py
@@ -46,6 +46,7 @@ class DefaultConfig(object):
     SELECTIONLISTS_CONFIG_DIR = '/opt/etc/munimap/selectionlists-configs'
     PLUGIN_DIR = '/opt/etc/munimap/plugins'
     TOUR_DIR = '/opt/etc/munimap/tours'
+    CONTEXTMENU_DIR = '/opt/etc/munimap/contextmenus'
 
     ASSETS_DEBUG = False
     ASSETS_BUNDLES_CONF = path.join(path.dirname(__file__), 'asset_bundles.yaml')

--- a/munimap/helper.py
+++ b/munimap/helper.py
@@ -299,6 +299,13 @@ def tour_file_path(name):
     )
 
 
+def contextmenu_file_path(name):
+    return os.path.join(os.path.abspath(
+        current_app.config.get('CONTEXTMENU_DIR')),
+        name + '.js'
+    )
+
+
 def list_projects():
     configs = glob.glob(os.path.join(os.path.abspath(
         current_app.config.get('APP_CONFIG_DIR')),

--- a/munimap/static/js/base-config.js
+++ b/munimap/static/js/base-config.js
@@ -98,6 +98,7 @@ angular.module('munimapBase', [
 ])
 
     .value('Tour', false)
+    .value('ContextMenuItems', false)
 
     .config(['$locationProvider', function ($locationProvider) {
         $locationProvider.hashPrefix('');

--- a/munimap/static/js/base-controller.js
+++ b/munimap/static/js/base-controller.js
@@ -9,9 +9,9 @@ import {transformExtent, transform} from 'ol/proj';
 angular.module('munimapBase')
     .controller('baseController', ['$rootScope', '$scope', '$window', '$timeout', '$translate', '$location', '$uibModal',
         'munimapConfig', 'ControlsService', 'MapService', 'NotificationService', 'DrawService', 'ClusterSelectService',
-        'Tour', 'SaveSettingsService', 'GeocoderService', 'CatalogService', 'PostMessageService', 'ReadyService',
+        'Tour', 'ContextMenuItems', 'SaveSettingsService', 'GeocoderService', 'CatalogService', 'PostMessageService', 'ReadyService',
         function($rootScope, $scope, $window, $timeout, $translate, $location, $uibModal, munimapConfig, ControlsService,
-                 MapService, NotificationService, DrawService, ClusterSelectService, Tour, SaveSettingsService,
+                 MapService, NotificationService, DrawService, ClusterSelectService, Tour, ContextMenuItems, SaveSettingsService,
                  GeocoderService, CatalogService, PostMessageService, ReadyService) {
 
             $scope.printEnabled = munimapConfig.components.print === true;
@@ -600,16 +600,14 @@ angular.module('munimapBase')
                     });
                 }
 
-                if (typeof contextmenuItems !== 'undefined') {
-                    if (angular.isDefined(contextmenuItems)) {
-                        var contextmenu = new anol.control.ContextMenu({
-                            width: 180,
-                            items: contextmenuItems
-                        });
-                        var map = MapService.getMap();
-                        map.addControl(contextmenu);
-                        contextmenu.enable();
-                    }
+                if (ContextMenuItems) {
+                    var contextmenu = new anol.control.ContextMenu({
+                        width: 180,
+                        items: ContextMenuItems
+                    });
+                    var map = MapService.getMap();
+                    map.addControl(contextmenu);
+                    contextmenu.enable();
                 }
             };
 

--- a/munimap/templates/munimap/app/index.html
+++ b/munimap/templates/munimap/app/index.html
@@ -198,93 +198,11 @@
     <script type="text/javascript" src="{$ url_for('frontend.tours', name=app_config['app']['tour']) $}"></script>
   {% endif %}
 
-
-  <script type="text/javascript">
-    let contextmenuItems = [{
-      text: 'Starte 3D-Stadtmodell',
-      title: 'Startet das 3D-Stadtmodell an dieser Koordinate',
-      link: true,
-      callback: start3D
-    },
-    {
-      text: 'Starte Schrägluftbilder',
-      title: 'Startet den Schrägluftbild-Viewer an dieser Koordinate',
-      link: true,
-      callback: startAero
-    },
-    {
-      text: 'Starte OpenStreetMap',
-      title: 'Startet OpenStreetMap an dieser Koordinate',
-      link: true,
-      callback: startOSM
-    },
-    {
-      text: 'Starte Google Maps',
-      title: 'Startet Google Maps an dieser Koordinate',
-      link: true,
-      callback: startGoogleMaps
-    }
-    {% if app_config.get('app',{})['contextMenu'] == 'index_intern.html' %}
-    , {
-      text: 'Starte StreetSmart',
-      title: 'Startet die Anwendung StreetSmart mit der Straßenpanorama-Aufnahme (Cyclorama) an dieser Koordinate',
-      link: true,
-      callback: startStreetSmart
-    },
-    {
-      text: 'Klick-Koordinaten',
-      title: 'Startet eine Umrechnung der Koordinate in unterschiedliche Koordinatensysteme',
-      link: true,
-      callback: startCoordTransform
-    }
-    {% endif %}
-    ];
-
-    function startGoogleMaps(obj) {
-      let zoom = obj['zoom'] + 4
-      let url = 'https://www.google.de/maps/@' + obj['coordinates']['EPSG:4326'][1] +
-        ',' + obj['coordinates']['EPSG:4326'][0] + ',' + zoom + 'z';
-      return url;
-    }
-
-    {% if app_config.get('app',{})['contextMenu'] == 'index_intern.html' %}
-    function startCoordTransform(obj) {
-      let rw = obj['coordinates']['EPSG:25832'][0].toFixed(1);
-      let hw = obj['coordinates']['EPSG:25832'][1].toFixed(1);
-      let url = '{$ base_config.get('COORD_TRANSFORM_URL') $}?rw=' + rw + '&hw=' + hw;
-      return url;
-    }
-
-    function startStreetSmart(obj) {
-      let rw = obj['coordinates']['EPSG:25832'][0].toFixed(2);
-      let hw = obj['coordinates']['EPSG:25832'][1].toFixed(2);
-      let url = 'https://streetsmart.cyclomedia.com/streetsmart/?q=' + rw + ';' + hw + ';EPSG:25832';
-      return url;
-    }
-    {% endif %}
-
-    function startOSM(obj) {
-      let zoom = obj['zoom'] + 4;
-      let url = 'https://www.openstreetmap.org/#map=' + zoom +
-        '/' + obj['coordinates']['EPSG:4326'][1] +
-        '/' + obj['coordinates']['EPSG:4326'][0];
-      return url;
-    }
-
-    {% if app_config.get('app',{})['contextMenu'] == 'index_intern.html' %}
-    const geoplexBaseURL = '{$ base_config.get('GEOPLEX_BASE_INTERN_URL') $}';
-    {% else %}
-    const geoplexBaseURL = '{$ base_config.get('GEOPLEX_BASE_EXTERN_URL') $}';
-    {% endif %}
-
-    function startAero(obj) {
-      return geoplexBaseURL + '?x=' + obj.coordinates['EPSG:25832'][0] + '&y=' + obj.coordinates['EPSG:25832'][1] + '&yaw=0&elevation=150';
-    }
-
-    function start3D(obj) {
-      return geoplexBaseURL + '?state=cesium&x=' + obj.coordinates['EPSG:25832'][0] + '&y=' + obj.coordinates['EPSG:25832'][1] + '&yaw=0&elevation=150';
-    }
-  </script>
+  {% if app_config.get('app', {}).get('contextMenu') == True %}
+    <script type="text/javascript" src="{$ url_for('frontend.contextmenus', name='index') $}"></script>
+  {% elif app_config.get('app', {}).get('contextMenu') %}
+    <script type="text/javascript" src="{$ url_for('frontend.contextmenus', name=app_config['app'].get('contextMenu')) $}"></script>
+  {% endif %}
 
 {% endblock %}
 

--- a/munimap/views/frontend.py
+++ b/munimap/views/frontend.py
@@ -8,7 +8,7 @@ from flask import (
     abort,
     send_file,
 )
-from munimap.helper import plugin_file_path, tour_file_path
+from munimap.helper import plugin_file_path, tour_file_path, contextmenu_file_path
 
 frontend = Blueprint('frontend', __name__)
 
@@ -37,5 +37,15 @@ def tours(name):
     try:
         # name cannot contain a '/' so the following is ok:
         return send_file(tour_file_path(name))
+    except IOError:
+        abort(404)
+
+
+@frontend.route('/contextmenus', defaults={'name': ''})
+@frontend.route('/contextmenus/<string:name>')
+def contextmenus(name):
+    try:
+        # name cannot contain a '/' so the following is ok:
+        return send_file(contextmenu_file_path(name))
     except IOError:
         abort(404)


### PR DESCRIPTION
Adds integration for contextmenus. The approach itself changed a little bit, for the merit of a cleaner code structure.

Instead of placed in the source directory, the path to contextmenus can now be configured via the `CONTEXTMENU_DIR` config variable. The default points to `/opt/etc/munimap/contextmenus`.

Instead of HTML-files containing a `script`-tag, contextmenus now have to be plain JavaScript files (`.js`), and should be written as immediately invoked function expressions to avoid exposing global variables.