### PR TITLE
fix: use secrets for checking access to api

### DIFF
--- a/munimap/config.py
+++ b/munimap/config.py
@@ -27,9 +27,13 @@ class DefaultConfig(object):
     LOG_STATS_BACKUP_COUNT = 5
     LOG_STATS_WHITELIST = ['http://localhost']
 
-    # TODO Check if this acutally applies
-    ALLOW_UPLOAD_CONFIG = ['127.0.0.1']
-    API_PRODUCTION_URL = 'http://localhost:8080'
+    # Access token of the target server.
+    # This should match the API_ACCESS_RECEIVE_TOKEN
+    # of the target server.
+    API_ACCESS_SEND_TOKEN = False
+    # Access token to compare incoming requests with.
+    API_ACCESS_RECEIVE_TOKEN = False
+    API_PRODUCTION_URL = 'http://localhost'
 
     PREFERRED_URL_SCHEME = 'http'
 

--- a/munimap/transfer.py
+++ b/munimap/transfer.py
@@ -14,7 +14,12 @@ def transfer_config(filename, type_='map'):
     if not os.path.exists(filename):
         return False
 
-    files = {'upload_file': open(filename, 'rb')}
+    files = {
+        'upload_file': open(filename, 'rb'),
+    }
+    api_access_token = current_app.config.get('API_ACCESS_SEND_TOKEN')
+    if api_access_token:
+        files['access_token'] = api_access_token
 
     if type_ == 'map':
         url = "%s%s" % (

--- a/munimap/transfer.py
+++ b/munimap/transfer.py
@@ -14,12 +14,11 @@ def transfer_config(filename, type_='map'):
     if not os.path.exists(filename):
         return False
 
-    files = {
-        'upload_file': open(filename, 'rb'),
-    }
+    files = {'upload_file': open(filename, 'rb')}
+    headers = {}
     api_access_token = current_app.config.get('API_ACCESS_SEND_TOKEN')
     if api_access_token:
-        files['access_token'] = api_access_token
+        headers['Authorization'] = f'munimap-token {api_access_token}'
 
     if type_ == 'map':
         url = "%s%s" % (
@@ -34,7 +33,7 @@ def transfer_config(filename, type_='map'):
 
     log.info('send config to %s', url)
 
-    r = requests.post(url, files=files)
+    r = requests.post(url, files=files, headers=headers)
     if not r.ok:
         return False
     content = json.loads(r.content)

--- a/munimap/views/api.py
+++ b/munimap/views/api.py
@@ -24,18 +24,18 @@ api = Blueprint('api', __name__, url_prefix='/api')
 
 @api.before_request
 def check_permission():
-    access_allowed = False
+    api_access_receive_token = current_app.config.get('API_ACCESS_RECEIVE_TOKEN')
 
-    if not current_app.config.get('ALLOW_UPLOAD_CONFIG'):
+    if not api_access_receive_token:
         return abort(403)
 
-    requested_ip = LocalProxyRequest.headers.get('X-Forwarded-For', False)
-    if current_app.config.get('DEBUG'):
-        requested_ip = '127.0.0.1'
+    access_token_file = LocalProxyRequest.files.get('access_token')
+    if access_token_file is None:
+        return abort(403)
 
-    if requested_ip in current_app.config.get('ALLOW_UPLOAD_CONFIG'):
-        access_allowed = True
+    access_token = access_token_file.read().decode('utf-8')
 
+    access_allowed = access_token == api_access_receive_token
     if not access_allowed:
         if LocalProxyRequest.is_xhr:
             return jsonify(message='Not allowed')

--- a/munimap/views/api.py
+++ b/munimap/views/api.py
@@ -29,11 +29,12 @@ def check_permission():
     if not api_access_receive_token:
         return abort(403)
 
-    access_token_file = LocalProxyRequest.files.get('access_token')
-    if access_token_file is None:
+    auth_header = LocalProxyRequest.headers.get('Authorization', '').split(' ')
+    if len(auth_header) != 2:
         return abort(403)
-
-    access_token = access_token_file.read().decode('utf-8')
+    scheme, access_token = auth_header
+    if scheme != 'munimap-token' or not access_token:
+        return abort(403)
 
     access_allowed = access_token == api_access_receive_token
     if not access_allowed:


### PR DESCRIPTION
This replaces the ip check of the x-forwarded-for header with a check of access tokens.