### PR TITLE
fix: update mobiel to support latest transport api

### DIFF
--- a/munimap/config.py
+++ b/munimap/config.py
@@ -148,19 +148,12 @@ class DefaultConfig(object):
     TRANSPORT_OPERATOR = '%'
     TRANSPORT_MAX_EXTENT = [-180, -85, 180, 85]  # to limit and speed-up db queries
 
-    TIMETABLE_SERVICE_URL = 'http://efa.vrr.de/vrr/XSLT_TRIP_REQUEST2'
-    TIMETABLE_SERVICE_CHARSET = 'ISO-8859-15'
+    TIMETABLE_SERVICE_URL = 'https://westfalenfahrplan.de'
+    TIMETABLE_STOPFINDER_API = '/nwl-efa/XML_STOPFINDER_REQUEST?coordOutputFormat=WGS84[dd.dddd]&language=de&locationInfoActive=1&locationServerActive=1&nwlStopFinderMacro=1&outputFormat=rapidJSON&serverInfo=1&sl3plusStopFinderMacro=1&type_sf=stop&version=10.4.18.18'
+    TIMETABLE_TRIP_API = '/nwlsl3+/trip?lng=de&sharedLink=true'
 
     TIMETABLE_DEFAULT_CTIY = 'Bielefeld'
 
-    TIMETABLE_STATIC_FIELDS = [
-        ('language', 'de'),
-        ('0', 'sessionID'),
-        ('type_origin', 'stop'),
-        ('type_destination', 'stop'),
-        # timetable style for given company
-        ('itdLPxx_transpCompany', 'mobiel2')
-    ]
     TIMETABLE_DOCUMENTS_CSV = False
     TIMETABLE_DOCUMENTS_BASE_URL = ''
 

--- a/munimap_transport/munimap_transport/static/js/app.js
+++ b/munimap_transport/munimap_transport/static/js/app.js
@@ -22,4 +22,5 @@ require('./transport-config.js');
 require('./layers.js');
 require('./transport-controller.js');
 require('./route-controller.js');
+require('./transport-api-service.js');
 require('./timetable-controller.js');

--- a/munimap_transport/munimap_transport/static/js/timetable-controller.js
+++ b/munimap_transport/munimap_transport/static/js/timetable-controller.js
@@ -1,8 +1,39 @@
 angular.module('munimapBase')
-    .controller('TimetableController', ['$scope', function($scope) {
-        $scope.addCharset = function(charset) {
-           // add charset to document to send umlauts correct
-           // using the ie - for other browser document.charset is read only
-           document.charset = charset;
-        };
-    }]);
+    .controller('TimetableController', ['$scope', 'TransportApiService',
+        function($scope, TransportApiService) {
+            $scope.onSubmit = (evt) => {
+                evt.preventDefault();
+                const form = new FormData(evt.target);
+                const originVals = {
+                    place: form.get('place_origin'),
+                    name: form.get('name_origin')
+                };
+                const destinationVals = {
+                    place: form.get('place_destination'),
+                    name: form.get('name_destination')
+                };
+                const promises = [
+                    TransportApiService.getStop(originVals),
+                    TransportApiService.getStop(destinationVals)
+                ];
+                Promise.allSettled(promises).then(results => {
+                    const [originStop, destinationStop] = results.map(r => r.value);
+                    const tripUrl = TransportApiService.createTripUrl({
+                        originStop,
+                        destinationStop,
+                        time: form.get('itdTime'),
+                        date: form.get('date-input')
+                    });
+                    const hiddenTripAnchor = evt.target.querySelector('#hidden-trip-anchor');
+                    if (hiddenTripAnchor) {
+                        // we directly manipulate the href here instead of using
+                        // ng-href with scope variable, since the latter did not
+                        // yet update the href when triggering the click event.
+                        hiddenTripAnchor.href = tripUrl;
+                        hiddenTripAnchor.click();
+                        // resetting hidden anchor
+                        hiddenTripAnchor.href = '';
+                    }
+                });
+            };
+        }]);

--- a/munimap_transport/munimap_transport/static/js/transport-api-service.js
+++ b/munimap_transport/munimap_transport/static/js/transport-api-service.js
@@ -1,0 +1,79 @@
+angular.module('munimapBase')
+    .provider('TransportApiService', [function (timetableServiceURL, timetableStopfinderAPI, timetableTripAPI) {
+        this.$get = ['$http', 'timetableServiceURL', 'timetableStopfinderAPI', 'timetableTripAPI',
+            function($http, timetableServiceURL, timetableStopfinderAPI, timetableTripAPI) {
+                const TransportApi = function () {};
+
+                TransportApi.prototype.createStopRequest = function (opts) {
+                    const stopName = `${opts.place ? opts.place : ''}%20${opts.name ? opts.name : ''}`;
+                    let url = new URL(timetableStopfinderAPI, timetableServiceURL);
+                    // We cannot use the searchParams features of the URL class here since
+                    // the API endpoint expects space in the query parameter 'name_sf' to be
+                    // encoded as %20 instead of +.
+                    url = url + `&name_sf=${stopName}`;
+                    return $http.get(url);
+                };
+
+                TransportApi.prototype.createTripUrl = function (opts) {
+                    const {
+                        originStop,
+                        destinationStop,
+                        time,
+                        date
+                    } = opts;
+                    const url = new URL(timetableTripAPI, timetableServiceURL);
+                    const formikParams = [
+                        'itdTripDateTimeDepArr=dep'
+                    ];
+
+                    if (originStop) {
+                        const originParam = `origin=${originStop}`;
+                        formikParams.push(originParam);
+                    }
+                    if (destinationStop) {
+                        const destinationParam = `destination=${destinationStop}`;
+                        formikParams.push(destinationParam);
+                    }
+                    if (time) {
+                        let [hours, minutes] = time.split(':');
+                        if (hours && minutes) {
+                            hours = hours.padStart(2, '0');
+                            minutes = minutes.padStart(2, '0');
+                            const timeFormatted = hours + minutes;
+                            const timeParam = `itdTime=${timeFormatted}`;
+                            formikParams.push(timeParam);
+                        }
+                    }
+                    if (date) {
+                        let [days, months, years] = date.split('.');
+                        if (days && months && years) {
+                            days = days.padStart(2, '0');
+                            months = months.padStart(2, '0');
+                            years = years.padStart(4, '0');
+                            const dateFormatted = days + months + years;
+                            const dateParam = `itdDateDayMonthYear=${dateFormatted}`;
+                            formikParams.push(dateParam);
+                        }
+                    }
+
+                    const formikParamString = formikParams.join('&');
+                    url.searchParams.set('formik', formikParamString);
+
+                    return url.href;
+                };
+
+                TransportApi.prototype.getStop = function (opts) {
+                    return this.createStopRequest(opts).then(res => {
+                        const stop = res.data.locations?.filter(i => i.isBest).shift();
+                        if (!stop) {
+                            return;
+                        }
+                        return stop.id;
+                    });
+                };
+
+                const transportApi = new TransportApi();
+
+                return transportApi;
+            }];
+    }]);

--- a/munimap_transport/munimap_transport/templates/transport/app/index.html
+++ b/munimap_transport/munimap_transport/templates/transport/app/index.html
@@ -55,7 +55,10 @@
     .constant('ProjectSettings', [])
     .constant('routesUrl', '{$ url_for("transport.route") $}')
     .constant('stationLayerURL', '{$ url_for("transport.stations") $}')
-    .constant('stationPointLayerURL', '{$ url_for("transport.station_points") $}');
+    .constant('stationPointLayerURL', '{$ url_for("transport.station_points") $}')
+    .constant('timetableServiceURL', {$ config['TIMETABLE_SERVICE_URL'] | tojson $})
+    .constant('timetableStopfinderAPI', {$ config['TIMETABLE_STOPFINDER_API'] | tojson $})
+    .constant('timetableTripAPI', {$ config['TIMETABLE_TRIP_API'] | tojson $});
 
     angular.module('munimap')
     .config(['LayersServiceProvider',

--- a/munimap_transport/munimap_transport/templates/transport/app/timetable.html
+++ b/munimap_transport/munimap_transport/templates/transport/app/timetable.html
@@ -11,10 +11,8 @@
   </h4>
   <form target="_blank"
         accept-charset="UTF-8"
-        method="POST"
-        action="{$ config['TIMETABLE_SERVICE_URL'] $}"
         ng-show="showTimetable"
-        ng-submit="addCharset('UTF-8')"
+        ng-submit="onSubmit($event)"
         ng-controller="TimetableController">
     <input 
         type="hidden"
@@ -27,9 +25,6 @@
         ng-value=timetableInformation.placeOrigin />
    
     <input type="hidden" name="itdDate" value="{{ formattedJourneyDate() }}" />
-    {% for static_field in config['TIMETABLE_STATIC_FIELDS'] %}
-    <input type="hidden" name="{$ static_field[0] $}" value="{$ static_field[1] $}" />
-    {% endfor %}
 
     <div class="row">
       <div class="col-xs-12">
@@ -82,5 +77,7 @@
       </div>
     </div>
 
+    <!-- using hidden input to circumvent popup blocking of the browser -->
+    <a style="visibility: hidden" id="hidden-trip-anchor" target="_blank"></a>
   </form>
 </div>


### PR DESCRIPTION
This applies changes in the mobiel app to work with the lateset transport api.

![munimap-mobiel-api](https://github.com/stadt-bielefeld/bielefeldGEOCLIENT/assets/12186477/01504fa8-4252-4710-b9f2-e2482968e0db)
