### PR TITLE
feat: add stopfinder priorities

### DIFF
--- a/munimap/config.py
+++ b/munimap/config.py
@@ -150,6 +150,7 @@ class DefaultConfig(object):
 
     TIMETABLE_SERVICE_URL = 'https://westfalenfahrplan.de'
     TIMETABLE_STOPFINDER_API = '/nwl-efa/XML_STOPFINDER_REQUEST?coordOutputFormat=WGS84[dd.dddd]&language=de&locationInfoActive=1&locationServerActive=1&nwlStopFinderMacro=1&outputFormat=rapidJSON&serverInfo=1&sl3plusStopFinderMacro=1&type_sf=stop&version=10.4.18.18'
+    TIMETABLE_STOPFINDER_PRIORITIES = ['bielefeld', 'bi-']
     TIMETABLE_TRIP_API = '/nwlsl3+/trip?lng=de&sharedLink=true'
 
     TIMETABLE_DEFAULT_CTIY = 'Bielefeld'

--- a/munimap_transport/munimap_transport/templates/transport/app/index.html
+++ b/munimap_transport/munimap_transport/templates/transport/app/index.html
@@ -58,7 +58,8 @@
     .constant('stationPointLayerURL', '{$ url_for("transport.station_points") $}')
     .constant('timetableServiceURL', {$ config['TIMETABLE_SERVICE_URL'] | tojson $})
     .constant('timetableStopfinderAPI', {$ config['TIMETABLE_STOPFINDER_API'] | tojson $})
-    .constant('timetableTripAPI', {$ config['TIMETABLE_TRIP_API'] | tojson $});
+    .constant('timetableTripAPI', {$ config['TIMETABLE_TRIP_API'] | tojson $})
+    .constant('timetableStopfinderPriorities', {$ config['TIMETABLE_STOPFINDER_PRIORITIES'] | tojson $});
 
     angular.module('munimap')
     .config(['LayersServiceProvider',


### PR DESCRIPTION
This adds stopfinder priorities. Through these, it is possible to prioritize items containing one of the listed keywords for the stops returned by the stopfinder request.