### PR TITLE
fix: stop running alembic on munimap-print-worker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -160,6 +160,9 @@ RUN mkdir -p /certs
 
 COPY ./entrypoint.sh /entrypoint.sh
 
+# Flag to decide if alembic should be run before starting the application
+ENV RUN_ALEMBIC="true"
+
 ENTRYPOINT ["/entrypoint.sh"]
 
 CMD ["gunicorn", "-c", "/opt/etc/munimap/gunicorn.conf", "munimap.application:create_app(config_file='/opt/etc/munimap/configs/munimap.conf')"]

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -62,6 +62,7 @@ services:
       # Because of failing DIN A0 prints in production, the heap size needed to be increased to 4gb
       # TODO: When removing the mapfish CLI this option can be removed from this container
       JAVA_OPTS: -Xmx4096m -Djava.awt.headless=true
+      RUN_ALEMBIC: false
     depends_on:
       munimap-postgis:
         condition: service_healthy

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -14,7 +14,7 @@ update-ca-certificates
 
 # run alembic
 
-if [ "$RUN_ALEMBIC" = true ] ; then
+if [ "$RUN_ALEMBIC" = "true" ] ; then
   alembic -c configs/alembic.ini upgrade head
 fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -14,7 +14,9 @@ update-ca-certificates
 
 # run alembic
 
-alembic -c configs/alembic.ini upgrade head
+if [ "$RUN_ALEMBIC" = true ] ; then
+  alembic -c configs/alembic.ini upgrade head
+fi
 
 # run the actual CMD
 


### PR DESCRIPTION
This stops the munimap-print-worker from running alembic since db migrations are already handled by munimap-app