### PR TITLE
Anol only in dockerfile

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,7 +8,6 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
-  ANOL_COMMIT_HASH: 2cb346052f6c37a00bebfb0189c4049dafd44f5b
 
 jobs:
   build-and-push-image:
@@ -41,8 +40,6 @@ jobs:
         with:
           context: .
           push: true
-          build-args: |
-            ANOL_COMMIT_HASH=${{ env.ANOL_COMMIT_HASH }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,7 +2,7 @@ Release Workflow
 ----------------
 
 1. Update Version in `pyproject.toml`
-1. Update `ANOL_COMMIT_HASH` in `.github/workflows/publish.yml` if needed
+1. Update `ANOL_COMMIT_HASH` in the Dockerfile if needed
 1. Create commit and merge
     ```bash
     git commit -m "chore: version update 1.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -78,8 +78,8 @@
         "jquery": ">=3.5.0",
         "lint": "^1.1.2",
         "lodash": "^4.17.15",
-        "ol": "^5.2.0",
-        "ol-ext": "^3.0.1",
+        "ol": "^10.2.1",
+        "ol-ext": "^4.0.24",
         "proj4": "^2.4.4",
         "voca": "^1.4.0"
       },
@@ -11509,8 +11509,8 @@
         "mini-css-extract-plugin": "^0.4.1",
         "napa": "^3.0.0",
         "node-sass": "^4.9.2",
-        "ol": "^5.2.0",
-        "ol-ext": "^3.0.1",
+        "ol": "^10.2.1",
+        "ol-ext": "^4.0.24",
         "proj4": "^2.4.4",
         "sass-loader": "^7.1.0",
         "style-loader": "^0.22.0",
@@ -11824,8 +11824,7 @@
           "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
         },
         "ol": {
-          "version": "5.3.3",
-          "resolved": "https://registry.npmjs.org/ol/-/ol-5.3.3.tgz",
+          "version": "https://registry.npmjs.org/ol/-/ol-5.3.3.tgz",
           "integrity": "sha512-7eU4x8YMduNcED1D5wI+AMWDRe7/1HmGfsbV+kFFROI9RNABU/6n4osj6Q3trZbxxKnK2DSRIjIRGwRHT/Z+Ww==",
           "requires": {
             "pbf": "3.1.0",
@@ -11834,8 +11833,7 @@
           }
         },
         "ol-ext": {
-          "version": "3.2.24",
-          "resolved": "https://registry.npmjs.org/ol-ext/-/ol-ext-3.2.24.tgz",
+          "version": "https://registry.npmjs.org/ol-ext/-/ol-ext-3.2.24.tgz",
           "integrity": "sha512-4I6YbGvgeb+FOym1PGxK0dWj3l7ZOeIPYWl+Hwp8DtmU0RljyMBzm5wYT93fOGf0rwNpSyHYem+7iTYeeMTpUg=="
         },
         "param-case": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = 'hatchling.build'
 
 [project]
 name = 'munimap'
-version = '1.3.0'
+version = '1.3.1'
 maintainers = [
     { name = 'terrestris GmbH & Co. KG', email = 'info@terrestris.de' }
 ]


### PR DESCRIPTION
This removes the use of the ANOL_COMMIT_HASH from the publish workflow so it is only necessary to change it in the Dockerfile.