### PR TITLE
Application error

### DIFF
--- a/dev/README.md
+++ b/dev/README.md
@@ -139,19 +139,13 @@ npm start
     cd dev/
     export FLASK_APP="manage.py"
     ```
-- `flask run-munimap`
+- `FLASK_DEBUG=1 flask run-munimap`
   
 By default a configuration file located in the `dev/` folder is used. However you can use a custom file by providing `FLASK_MUNIMAP_CONFIG` environment variable:
-- `FLASK_APP=manage.py FLASK_MUNIMAP_CONFIG='../path/to/your/custom/config/file.conf' flask run-munimap`
-
-For debugging purposes, you may use the environment variable `FLASK_DEBUG=1` if not set in the configuration file
-- `FLASK_DEBUG=1 FLASK_APP=manage.py flask run-munimap`
-
-You can also set the environment your app is running on by setting the `FLASK_ENV=development` environment variable, if not already in the config file
-- `FLASK_ENV=development FLASK_APP=manage.py flask run-munimap`
+- `FLASK_DEBUG=1 FLASK_APP=manage.py FLASK_MUNIMAP_CONFIG='../path/to/your/custom/config/file.conf' flask run-munimap`
 
 If you want to use mapfish CLI instead of service and have not configured Java 8 as the default Java Version, you need to set the `JAVA_HOME` environment variable. i.e.:
-- `JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64/ FLASK_APP=manage.py flask run-munimap`
+- `JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64/ FLASK_DEBUG=1 FLASK_APP=manage.py flask run-munimap`
 
 ## Compile the frontend
 and finally the client (javascript) source can be watched via(ran in the root folder, i.e, bielefeldGEOCLIENT):

--- a/dev/configs/munimap.conf
+++ b/dev/configs/munimap.conf
@@ -15,8 +15,6 @@ def printqueue(rel_path):
 def mapfish(rel_path):
     return path.join('/usr/local/tomcat/webapps/ROOT/print-apps/munimap', rel_path)
 
-DEBUG = True
-
 MATOMO = False
 MATOMO_URL = 'https://example.org'
 MATOMO_IMAGE_URL = 'https://example.org'

--- a/dev/manage.py
+++ b/dev/manage.py
@@ -5,7 +5,7 @@ from munimap.extensions import db
 import click
 
 config_file = os.getenv('FLASK_MUNIMAP_CONFIG', './configs/munimap.conf')
-debug = os.getenv('FLASK_DEBUG', '0')
+debug = os.getenv('FLASK_DEBUG', '0') == '1'
 host = os.getenv('FLASK_RUN_HOST', '0.0.0.0')
 port = os.getenv('FLASK_RUN_PORT', 5000)
 
@@ -19,8 +19,8 @@ def run_munimap():
     app.logger.info("Preparing to run munimap")
     app.logger.info(f"Starting application {app.name}")
     app.logger.info(f"Using {config_file} as config file")
-    app.logger.info(f"Debugger is {debug == '1'}")
-    app.run(host=host, port=int(port), debug=debug=="1", threaded=True)
+    app.logger.info(f"Debugger is {debug}")
+    app.run(host=host, port=int(port), debug=debug, threaded=True)
 
 @cli_manager.command()
 @click.option('--lang', default='de', help='selects language to initialize')

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -33,6 +33,8 @@ services:
       context: ../
       args:
         ANOL_COMMIT_HASH: master
+#    environment:
+#      FLASK_DEBUG: 1
     volumes:
       - ../dev/configs:/opt/etc/munimap/configs
       - ./munimap-app/alembic.ini:/opt/etc/munimap/configs/alembic.ini

--- a/docker/munimap-app/munimap.conf
+++ b/docker/munimap-app/munimap.conf
@@ -9,8 +9,6 @@ def config(rel_path):
 def data(rel_path):
   return path.abspath(path.join('/opt/etc/munimap/data', rel_path))
 
-DEBUG = True
-
 LOG_MODE = 'STDOUT'
 
 MATOMO = False

--- a/munimap/config.py
+++ b/munimap/config.py
@@ -7,10 +7,6 @@ class DefaultConfig(object):
     Default configuration for a newsmeme application.
     """
 
-    # TODO It is not recommended to set DEBUG value at runtime.
-    #      Better set it as environment variable before startup.
-    DEBUG = True
-
     MATOMO = False
     MATOMO_URL = ''
     MATOMO_IMAGE_URL = ''
@@ -179,9 +175,6 @@ class DefaultConfig(object):
 
 class TestConfig(object):
     here = path.dirname(__file__)
-
-    DEBUG = True
-    ASSETS_DEBUG = True
 
     APP_CONFIG_DIR = path.join(here, 'test/data/app/')
 

--- a/munimap/frontend/js/base-controller.js
+++ b/munimap/frontend/js/base-controller.js
@@ -53,16 +53,6 @@ angular.module('munimapBase')
                 $scope.geoeditorConfig = munimapConfig.geoeditor;
             }
 
-            const mutuallyExclusiveDrawComponents = [
-              $scope.drawEnabled,
-              $scope.geoeditorEnabled,
-              $scope.digitizeEnabled
-            ];
-            if (mutuallyExclusiveDrawComponents.filter(t => t).length > 1) {
-                // anol-draw does not support multiple instances. This causes the draw components to work on the same layer.
-                $scope.applicationError = 'The options draw, geoeditor and digitize cannot be enabled at the same time.';
-            }
-
             if ($scope.digitizeEnabled) {
               $scope.digitizeConfig = munimapConfig.digitizeConfig;
               $scope.digitizeLayerGeomType = undefined;

--- a/munimap/templates/munimap/app/index.html
+++ b/munimap/templates/munimap/app/index.html
@@ -11,11 +11,6 @@
 {% endblock %}
 
 {% block body %}
-  <div ng-show="applicationError"
-       class="alert alert-danger text-center"
-       ng-cloak>
-    <pre>{{ applicationError }}</pre>
-  </div>
   <div class="app-content hide"
        ng-controller="transportController"
        ng-class="{'show': appReady === true}">


### PR DESCRIPTION
This removes the application error notification from the frontend and moves it into the backend. This will cause more consistent error messages and avoids the occasionally visible notification without content.

This also includes some updates to READMEs regarding the usage of the `DEBUG` and `FLASK_DEBUG` flags.