### PR TITLE
fix: use single style appStyle.css for all pages

### DIFF
--- a/munimap/frontend/js/admin/admin.js
+++ b/munimap/frontend/js/admin/admin.js
@@ -1,7 +1,5 @@
 import '@babel/polyfill';
 
-import "../../sass/admin.sass";
-
 require('angular');
 
 require('./base.js');

--- a/munimap/frontend/js/app.js
+++ b/munimap/frontend/js/app.js
@@ -5,8 +5,6 @@ import '@babel/polyfill';
 proj4.defs('EPSG:25832', '+proj=utm +zone=32 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs');
 register(proj4);
 
-import '../sass/app.sass';
-
 require('angular-schema-form');
 require('angular-schema-form-bootstrap');
 require('anol/src/anol/anol.js');

--- a/munimap/frontend/js/munimap_transport/app.js
+++ b/munimap/frontend/js/munimap_transport/app.js
@@ -5,8 +5,6 @@ import '@babel/polyfill';
 proj4.defs('EPSG:25832', '+proj=utm +zone=32 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs');
 register(proj4);
 
-import '../../../../munimap/frontend/sass/transport.sass';
-
 require('angular');
 require('anol/src/anol/anol.js');
 

--- a/munimap/frontend/sass/appStyle.sass
+++ b/munimap/frontend/sass/appStyle.sass
@@ -14,6 +14,9 @@
 @use "components/sidebar"
 @use "components/timetable"
 
+@use "transport"
+@use "admin"
+
 /* Add additional media query to show on mobile devices */
 
 .iframe-project-link

--- a/munimap/frontend/sass/transport.sass
+++ b/munimap/frontend/sass/transport.sass
@@ -1,7 +1,6 @@
 @use "helpers/variables"
 @use "helpers/media_queries"
 
-@use "app"
 
 .app-content:not(.show) + .loading
   .logo-transport

--- a/munimap/templates/munimap/admin/index.html
+++ b/munimap/templates/munimap/admin/index.html
@@ -1,9 +1,5 @@
 {% extends "munimap/base.html" %}
 
-{% block header %}
-    <link href="{$ url_for('static', filename='css/admin.css') $}" rel="stylesheet" type="text/css">
-{% endblock %}
-
 {% block javascript %}
     {$ super() $}
 

--- a/munimap/templates/munimap/app/base.html
+++ b/munimap/templates/munimap/app/base.html
@@ -1,9 +1,5 @@
 {% extends "munimap/base.html" %}
 
-{% block header %}
-    <link href="{$ url_for('static', filename='css/app.css') $}" rel="stylesheet" type="text/css">
-{% endblock %}
-
 {% block javascript %}
     <script type="text/javascript" src="{$ url_for('static', filename='translations/de_DE.js') $}"></script>
     <script type="text/javascript" src="{$ url_for('static', filename='translations/de_DE_feature_properties.js') $}"></script>

--- a/munimap/templates/munimap/app/iframe.html
+++ b/munimap/templates/munimap/app/iframe.html
@@ -5,7 +5,6 @@
       {% include 'munimap/meta.html' %}
     {% endblock %}
 
-    <!-- TODO: integrate as imports into JS Files -->
     <link href="{$ url_for('static', filename='css/angular-ui-switch.css') $}" rel="stylesheet" type="text/css">
     <link href="{$ url_for('static', filename='css/anol.css') $}" rel="stylesheet" type="text/css">
     <link href="{$ url_for('static', filename='css/bootstrap.css') $}" rel="stylesheet" type="text/css">
@@ -16,7 +15,7 @@
     <link href="{$ url_for('static', filename='css/draw/spectrum.css') $}" rel="stylesheet" type="text/css">
 
     {% block header %}
-      <link href="{$ url_for('static', filename='css/app.css') $}" rel="stylesheet" type="text/css">
+      <link href="{$ url_for('static', filename='css/appStyle.css') $}" rel="stylesheet" type="text/css">
     {% endblock %}
 
   </head>

--- a/munimap/templates/munimap/base.html
+++ b/munimap/templates/munimap/base.html
@@ -13,6 +13,7 @@
     <link href="{$ url_for('static', filename='css/draw/bootstrap.vertical-tabs.css') $}" rel="stylesheet" type="text/css">
     <link href="{$ url_for('static', filename='css/draw/bootstrap-slider.css') $}" rel="stylesheet" type="text/css">
     <link href="{$ url_for('static', filename='css/draw/spectrum.css') $}" rel="stylesheet" type="text/css">
+    <link href="{$ url_for('static', filename='css/appStyle.css') $}" rel="stylesheet" type="text/css">
 
     {% block header %}
     {% endblock %}

--- a/munimap/templates/munimap/pages/base.html
+++ b/munimap/templates/munimap/pages/base.html
@@ -1,9 +1,5 @@
 {% extends "munimap/base.html" %}
 
-{% block header %}
-<link href="{$ url_for('static', filename='css/app.css') $}" rel="stylesheet" type="text/css">
-{% endblock %}
-
 {% block body %}
 
   {% block navbar %}

--- a/munimap/templates/munimap_transport/index.html
+++ b/munimap/templates/munimap_transport/index.html
@@ -1,10 +1,6 @@
 {% extends "munimap/app/base.html" %}
 {% from "munimap/macros/layers.html" import create_layers %}
 
-{% block header %}
-  <link href="{$ url_for('static', filename='css/transport.css') $}" rel="stylesheet" type="text/css">
-{% endblock %}
-
 {% block body %}
   <div class="app-content hide"
        ng-controller="transportController"

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -22,7 +22,10 @@ module.exports  = {
             import: './munimap/frontend/js/static-app.js',
             dependOn: 'vendor'
         },
-        vendor: ['angular', 'jquery', 'angular-ui-bootstrap']
+        vendor: ['angular', 'jquery', 'angular-ui-bootstrap'],
+        appStyle: {
+            import: './munimap/frontend/sass/appStyle.sass'
+        }
     },
     output: {
         filename: 'js/[name].bundle.js',


### PR DESCRIPTION
This creates a single css file for the whole application (as it was before). This should ensure that no new css bugs occur. This also adds a dedicated config for building the css in webpack. Through this the import statements in the js files are not needed anymore.