### PR TITLE
fix: provide ace workers on needed locations

### DIFF
--- a/munimap/frontend/js/admin/base.js
+++ b/munimap/frontend/js/admin/base.js
@@ -1,15 +1,15 @@
 require('angular-route');
-require('ace-builds');
+require('ace-builds/src-min-noconflict/ace.js');
 require('ace-builds/src-min-noconflict/ext-searchbox.js');
 require('ace-builds/src-min-noconflict/mode-yaml.js');
 require('ace-builds/src-min-noconflict/mode-javascript.js');
-require('ace-builds/src/worker-javascript.js');
+require('ace-builds/src-min-noconflict/worker-javascript.js');
+require('ace-builds/src-min-noconflict/worker-yaml.js');
 require('ace-builds/src-min-noconflict/theme-textmate.js');
 require('angular-ui-ace');
 require('angular-ui-bootstrap');
 require('./../modules/notifications.js');
 require('./../modules/confirm.js');
-
 
 Date.prototype.ddmmyyyy = function() {
     var mm = this.getMonth() + 1; // getMonth() is zero-based

--- a/package-lock.json
+++ b/package-lock.json
@@ -2838,9 +2838,10 @@
       "dev": true
     },
     "node_modules/ace-builds": {
-      "version": "1.36.2",
-      "resolved": "https://registry.npmjs.org/ace-builds/-/ace-builds-1.36.2.tgz",
-      "integrity": "sha512-eqqfbGwx/GKjM/EnFu4QtQ+d2NNBu84MGgxoG8R5iyFpcVeQ4p9YlTL+ZzdEJqhdkASqoqOxCSNNGyB6lvMm+A=="
+      "version": "1.37.5",
+      "resolved": "https://registry.npmjs.org/ace-builds/-/ace-builds-1.37.5.tgz",
+      "integrity": "sha512-VMJ4Cnhq6L9dwvOCyuyyvQuiVTSwdZC7zDKJBBBJJax0wGQ7MvzQZFoi0gMmCm2I4Zuv/ZbtwU/dlglIhCNLhw==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/acorn": {
       "version": "6.4.2",
@@ -8451,9 +8452,9 @@
       "dev": true
     },
     "ace-builds": {
-      "version": "1.36.2",
-      "resolved": "https://registry.npmjs.org/ace-builds/-/ace-builds-1.36.2.tgz",
-      "integrity": "sha512-eqqfbGwx/GKjM/EnFu4QtQ+d2NNBu84MGgxoG8R5iyFpcVeQ4p9YlTL+ZzdEJqhdkASqoqOxCSNNGyB6lvMm+A=="
+      "version": "1.37.5",
+      "resolved": "https://registry.npmjs.org/ace-builds/-/ace-builds-1.37.5.tgz",
+      "integrity": "sha512-VMJ4Cnhq6L9dwvOCyuyyvQuiVTSwdZC7zDKJBBBJJax0wGQ7MvzQZFoi0gMmCm2I4Zuv/ZbtwU/dlglIhCNLhw=="
     },
     "acorn": {
       "version": "6.4.2",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -44,14 +44,26 @@ module.exports  = {
     },
     module: {
         rules: [
+            // Small workaround for ace-builds to work.
+            // For some reason, the worker-javascript.js will be requested by ace under
+            // js/ace-builds/worker-javascript.js
+            // whereas the worker-yaml will be requested by ace under
+            // js/worker-yaml.js.
+            // So we handle the two files separately here and put them under different
+            // locations respectively.
             {
-                test: /ace-builds.*worker-.*\.js$/,
-                use: {
-                    loader: 'file-loader',
-                    options: {
-                        name: 'js/ace-builds/[name].js'
-                    }
-                }
+                test: /ace-builds.*worker-yaml\.js$/,
+                type: 'asset/resource',
+                generator: {
+                 filename: 'js/[name].js'
+               }
+            },
+            {
+                test: /ace-builds.*worker-javascript\.js$/,
+                type: 'asset/resource',
+                generator: {
+                 filename: 'js/ace-builds/[name].js'
+               }
             },
             {
                 test: /\.html$/,


### PR DESCRIPTION
This adds the missing `worker-yaml.js` and puts it on its needed location. For some reason, this location is different from the location of the `worker-javascript.js`. So we added a separate webpack rule. We also now use the minified ace.js to save around 0.7mb.