### PR TITLE
fix: use StringIO class instead of BytesIO

### DIFF
--- a/munimap/query/pq.py
+++ b/munimap/query/pq.py
@@ -1,3 +1,4 @@
+import logging
 from collections import OrderedDict
 import sqlalchemy as sa
 
@@ -5,6 +6,9 @@ from shapely.wkb import loads
 from shapely.geometry import mapping
 
 from munimap.model import Feature
+
+log = logging.getLogger('munimap.layers')
+
 
 class LayerNotFoundError(Exception):
     pass
@@ -36,6 +40,7 @@ def load_layers(config, default_db_uri, db_schema, db_echo=False):
                 engines[uri] = engine
 
             layer['source']['db_engine'] = engine
+        log.debug(f'Added queryable layer {layer["name"]} with config {str(layer)}')
         queryable_layers[layer['name']] = layer
 
     return queryable_layers

--- a/munimap/views/vector.py
+++ b/munimap/views/vector.py
@@ -1,7 +1,7 @@
 
 
 import csv
-from io import BytesIO
+from io import StringIO
 
 from flask import (
     Blueprint,
@@ -63,7 +63,7 @@ def index_csv():
     delimiter = request.args.get('delimiter', ';')[0]
     req = MapRequest.from_req(request)
     fc = query_feature_collection(req, current_app.pg_layers)
-    buf = BytesIO()
+    buf = StringIO()
     w = csv.writer(buf, delimiter=delimiter)
     for f in fc['features']:
         if f['properties'].get('__ref__'):


### PR DESCRIPTION
The existing code raised errors about the input being a `str` instead of `bytes`. Using the `StringIO` class instead of the `BytesIO` class solves this problem.