### PR TITLE
Cascade delete email verification

### DIFF
--- a/munimap/model/mb_user.py
+++ b/munimap/model/mb_user.py
@@ -82,8 +82,7 @@ class MBUser(db.Model, UserMixin):
     email_verification = db.relationship(
         'EmailVerification',
         backref='user',
-        uselist=False,
-        cascade='all, delete-orphan'
+        cascade='all, delete'
     )
 
     @property


### PR DESCRIPTION
The `uselist=False,` parameter marked this as a one-to-one relation which caused errors when deleting users with more then one password_recovery request.