### PR TITLE
chore: adjust stats logging for dev setup

### DIFF
--- a/dev/configs/logging.yaml
+++ b/dev/configs/logging.yaml
@@ -14,13 +14,10 @@ handlers:
     stream: ext://sys.stdout
 
   stats:
-    class: logging.NullHandler
-#    class: logging.handlers.RotatingFileHandler
-#    level: DEBUG
-#    formatter: stats
-#    filename: dev/data/stats/stats.log
-#    maxBytes: 1000000
-#    backupCount: 5
+    class: logging.StreamHandler
+    level: DEBUG
+    formatter: stats
+    stream: ext://sys.stdout
 
 loggers:
   munimap:

--- a/munimap/logging.yaml
+++ b/munimap/logging.yaml
@@ -14,13 +14,10 @@ handlers:
     stream: ext://sys.stdout
 
   stats:
-    class: logging.NullHandler
-#    class: logging.handlers.RotatingFileHandler
-#    level: DEBUG
-#    formatter: stats
-#    filename: /opt/etc/munimap/data/stats/stats.log
-#    maxBytes: 1000000
-#    backupCount: 5
+    class: logging.StreamHandler
+    level: DEBUG
+    formatter: stats
+    stream: ext://sys.stdout
 
 loggers:
   munimap:


### PR DESCRIPTION
This adjusts the stats logging config for the dev setup. There, we also use the StreamHandler now and write to stdout.