### PR TITLE
fix: ng-required

### DIFF
--- a/munimap/templates/munimap/app/ng-templates/settings-save.html
+++ b/munimap/templates/munimap/app/ng-templates/settings-save.html
@@ -15,7 +15,7 @@
         <div class="form-group" ng-show="!id">
             <label for="projectName">{$ _('Project Title') $}</label>
             <input type="text" class="form-control" 
-                ng-model="name" name="projectName" ng-required="true"/>
+                ng-model="name" name="projectName" ng-required="!id"/>
         </div>
 
         <div class="row">


### PR DESCRIPTION
This PR sets `ng-required` similar to `ng-show` as the `projectName` is only required when the input field is shown.

Please review @jansule  