### PR TITLE
refactor: convert require() to ES6 import (hybrid approach)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "conventionalCommits.scopes": [
+        "README",
+        "dev/README"
+    ]
+}

--- a/dev/README.md
+++ b/dev/README.md
@@ -217,13 +217,27 @@ docker compose -f docker/docker-compose.yaml --profile prod up
 
 ## Debugging the application
 
-# With VSCODE
+### With VSCODE
 A debug configuration is provided and can be found in `.vscode/launch.json`.
 If you are using a custom config file for your application, you have to change it's path in `FLASK_MUNIMAP_CONFIG`.
 Then all you need to do is start debugging with vscode
 
-# With PyCharm
+### With PyCharm
 TODO
+
+### Coding advice / best practices
+* ES6 imports are hoisted and execute before other code, which breaks Angular 1.x module registration that depends on sequential execution. Therefore please use
+  - `require` for local modules and sub-modules
+  - `import` for external libraries
+  e.g. 
+  ```javascript
+  import 'bootstrap3/js/popover.js';
+  import 'angular-schema-form-bootstrap';
+  import 'anol/src/anol/anol.js';
+  require('./base-config.js');
+  require('./draw-popup-controller.js');
+  require('./modules/colorpicker.js');
+  ```
 
 ## Testing the application
 

--- a/munimap/frontend/js/admin/base.js
+++ b/munimap/frontend/js/admin/base.js
@@ -1,13 +1,13 @@
-require('angular-route');
-require('ace-builds/src-min-noconflict/ace.js');
-require('ace-builds/src-min-noconflict/ext-searchbox.js');
-require('ace-builds/src-min-noconflict/mode-yaml.js');
-require('ace-builds/src-min-noconflict/mode-javascript.js');
-require('ace-builds/src-min-noconflict/worker-javascript.js');
-require('ace-builds/src-min-noconflict/worker-yaml.js');
-require('ace-builds/src-min-noconflict/theme-textmate.js');
-require('angular-ui-ace');
-require('angular-ui-bootstrap');
+import 'angular-route';
+import 'ace-builds/src-min-noconflict/ace.js';
+import 'ace-builds/src-min-noconflict/ext-searchbox.js';
+import 'ace-builds/src-min-noconflict/mode-yaml.js';
+import 'ace-builds/src-min-noconflict/mode-javascript.js';
+import 'ace-builds/src-min-noconflict/worker-javascript.js';
+import 'ace-builds/src-min-noconflict/worker-yaml.js';
+import 'ace-builds/src-min-noconflict/theme-textmate.js';
+import 'angular-ui-ace';
+import 'angular-ui-bootstrap';
 require('./../modules/notifications.js');
 require('./../modules/confirm.js');
 

--- a/munimap/frontend/js/alkis/selection.js
+++ b/munimap/frontend/js/alkis/selection.js
@@ -1,4 +1,4 @@
-require('ngstorage');
+import 'ngstorage';
 
 import { unByKey } from 'ol/Observable.js';
 import { getCenter } from 'ol/extent';

--- a/munimap/frontend/js/app.js
+++ b/munimap/frontend/js/app.js
@@ -5,9 +5,9 @@ import '@babel/polyfill';
 proj4.defs('EPSG:25832', '+proj=utm +zone=32 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs');
 register(proj4);
 
-require('angular-schema-form');
-require('angular-schema-form-bootstrap');
-require('anol/src/anol/anol.js');
+import 'angular-schema-form';
+import 'angular-schema-form-bootstrap';
+import 'anol/src/anol/anol.js';
 
 require('./default-munimap-config.js');
 require('./base-config.js');
@@ -48,4 +48,3 @@ require('./munimap_transport/transport-controller.js');
 require('./munimap_transport/route-controller.js');
 require('./munimap_transport/transport-api-service.js');
 require('./munimap_transport/timetable-controller.js');
-

--- a/munimap/frontend/js/base-config.js
+++ b/munimap/frontend/js/base-config.js
@@ -1,73 +1,73 @@
-require('angular');
+import 'angular';
 
-require('jquery-ui');
-require('jquery-ui/ui/widgets/mouse');
-require('jquery-ui/ui/widgets/sortable');
-require('jquery-ui/ui/disable-selection');
+import 'jquery-ui';
+import 'jquery-ui/ui/widgets/mouse';
+import 'jquery-ui/ui/widgets/sortable';
+import 'jquery-ui/ui/disable-selection';
 /*!
  * jQuery UI Touch Punch
  * https://github.com/furf/jquery-ui-touch-punch
  * Copyright (c) Dave Furfero
  * Released under the MIT license
  */
-require('jquery-ui-touch-punch');
-require('angular-ui-sortable');
+import 'jquery-ui-touch-punch';
+import 'angular-ui-sortable';
 
-require('anol/src/modules/module.js');
-require('anol/src/modules/map/map-service.js');
-require('anol/src/modules/legend/legend-directive.js');
+import 'anol/src/modules/module.js';
+import 'anol/src/modules/map/map-service.js';
+import 'anol/src/modules/legend/legend-directive.js';
 
-require('anol/src/modules/attribution/attribution-directive.js');
-require('anol/src/modules/catalog/catalog-directive.js');
-require('anol/src/modules/catalog/catalog-service.js');
+import 'anol/src/modules/attribution/attribution-directive.js';
+import 'anol/src/modules/catalog/catalog-directive.js';
+import 'anol/src/modules/catalog/catalog-service.js';
 
-require('anol/src/modules/datepicker/datepicker-directive.js');
-require('anol/src/modules/featurepopup/dragpopup-directive.js');
-require('anol/src/modules/draw/draw-directive.js');
-require('anol/src/modules/draw/draw-service.js');
-require('anol/src/modules/featureexchange/featureexchange-directive.js');
+import 'anol/src/modules/datepicker/datepicker-directive.js';
+import 'anol/src/modules/featurepopup/dragpopup-directive.js';
+import 'anol/src/modules/draw/draw-directive.js';
+import 'anol/src/modules/draw/draw-service.js';
+import 'anol/src/modules/featureexchange/featureexchange-directive.js';
 
-require('anol/src/modules/featurepopup/featurepopup-directive.js');
-require('anol/src/modules/featurepopup/featurepopup-service.js');
+import 'anol/src/modules/featurepopup/featurepopup-directive.js';
+import 'anol/src/modules/featurepopup/featurepopup-service.js';
 
-require('anol/src/modules/featureform/featureform-directive.js');
+import 'anol/src/modules/featureform/featureform-directive.js';
 
-require('anol/src/modules/featurepropertieseditor/featurepropertieseditor-directive.js');
-require('anol/src/modules/featureproperties/featureproperties-directive.js');
-require('anol/src/modules/featurestyleeditor/featurestyleeditor-directive.js');
-require('anol/src/modules/geocoder/geocoder-directive.js');
-require('anol/src/modules/geocoder/geocoder-service.js');
+import 'anol/src/modules/featurepropertieseditor/featurepropertieseditor-directive.js';
+import 'anol/src/modules/featureproperties/featureproperties-directive.js';
+import 'anol/src/modules/featurestyleeditor/featurestyleeditor-directive.js';
+import 'anol/src/modules/geocoder/geocoder-directive.js';
+import 'anol/src/modules/geocoder/geocoder-service.js';
 
-require('anol/src/modules/geolocation/geolocation-directive.js');
-require('anol/src/modules/getfeatureinfo/getfeatureinfo-directive.js');
-require('anol/src/modules/layerswitcher/layerswitcher-directive.js');
-require('anol/src/modules/map/map-directive.js');
-require('anol/src/modules/measure/measure-directive.js');
-require('anol/src/modules/measure/measure-service.js');
-require('anol/src/modules/mouseposition/mouseposition-directive.js');
-require('anol/src/modules/overviewmap/overviewmap-directive.js');
-require('anol/src/modules/permalink/permalink-service.js');
-require('anol/src/modules/print/print-directive.js');
-require('anol/src/modules/print/print-service.js');
-require('anol/src/modules/print/printpage-service.js');
-require('anol/src/modules/rotate/rotate-directive.js');
-require('anol/src/modules/savemanager/savemanager-directive.js');
-require('anol/src/modules/savemanager/savemanager-service.js');
-require('anol/src/modules/transparencysettings/transparencysettings-directive.js');
-require('anol/src/modules/transparencysettings/transparencydialog-directive.js');
+import 'anol/src/modules/geolocation/geolocation-directive.js';
+import 'anol/src/modules/getfeatureinfo/getfeatureinfo-directive.js';
+import 'anol/src/modules/layerswitcher/layerswitcher-directive.js';
+import 'anol/src/modules/map/map-directive.js';
+import 'anol/src/modules/measure/measure-directive.js';
+import 'anol/src/modules/measure/measure-service.js';
+import 'anol/src/modules/mouseposition/mouseposition-directive.js';
+import 'anol/src/modules/overviewmap/overviewmap-directive.js';
+import 'anol/src/modules/permalink/permalink-service.js';
+import 'anol/src/modules/print/print-directive.js';
+import 'anol/src/modules/print/print-service.js';
+import 'anol/src/modules/print/printpage-service.js';
+import 'anol/src/modules/rotate/rotate-directive.js';
+import 'anol/src/modules/savemanager/savemanager-directive.js';
+import 'anol/src/modules/savemanager/savemanager-service.js';
+import 'anol/src/modules/transparencysettings/transparencysettings-directive.js';
+import 'anol/src/modules/transparencysettings/transparencydialog-directive.js';
 
-require('anol/src/modules/savesettings/savesettings-directive.js');
-require('anol/src/modules/savesettings/savesettings-service.js');
+import 'anol/src/modules/savesettings/savesettings-directive.js';
+import 'anol/src/modules/savesettings/savesettings-service.js';
 
-require('anol/src/modules/scale/scaleline-directive.js');
-require('anol/src/modules/scale/scaletext-directive.js');
+import 'anol/src/modules/scale/scaleline-directive.js';
+import 'anol/src/modules/scale/scaletext-directive.js';
 
-require('anol/src/modules/urlmarkers/urlmarker-directive.js');
-require('anol/src/modules/urlmarkers/urlmarker-service.js');
-require('anol/src/modules/urlmarkers/urlmarker-bbcode-directive.js');
-require('anol/src/modules/zoom/zoom-directive.js');
+import 'anol/src/modules/urlmarkers/urlmarker-directive.js';
+import 'anol/src/modules/urlmarkers/urlmarker-service.js';
+import 'anol/src/modules/urlmarkers/urlmarker-bbcode-directive.js';
+import 'anol/src/modules/zoom/zoom-directive.js';
 
-require('anol/src/modules/drawer/drawer-directive.js');
+import 'anol/src/modules/drawer/drawer-directive.js';
 
 import View from 'ol/View';
 import { transformExtent, transform } from 'ol/proj';

--- a/munimap/frontend/js/base-controller.js
+++ b/munimap/frontend/js/base-controller.js
@@ -1,5 +1,5 @@
-require('angular-ui-bootstrap');
-require('bootstrap-tour');
+import 'angular-ui-bootstrap';
+import 'bootstrap-tour';
 import 'spectrum-colorpicker/spectrum';
 import 'spectrum-colorpicker/i18n/jquery.spectrum-de';
 

--- a/munimap/frontend/js/catalog-modal-controller.js
+++ b/munimap/frontend/js/catalog-modal-controller.js
@@ -1,4 +1,4 @@
-require('angular-ui-bootstrap');
+import 'angular-ui-bootstrap';
 
 angular.module('munimapBase')
     .controller('catalogModalController', ['Variant', 'ShowLayers', '$scope', '$uibModalInstance',

--- a/munimap/frontend/js/draw-layer-config.js
+++ b/munimap/frontend/js/draw-layer-config.js
@@ -1,6 +1,6 @@
-require('angular-ui-bootstrap');
-require('angular-schema-form');
-require('angular-schema-form-bootstrap');
+import 'angular-ui-bootstrap';
+import 'angular-schema-form';
+import 'angular-schema-form-bootstrap';
 
 angular.module('munimapDraw', [
     'schemaForm',

--- a/munimap/frontend/js/geoeditor/geoeditor-validation-service.js
+++ b/munimap/frontend/js/geoeditor/geoeditor-validation-service.js
@@ -216,3 +216,4 @@ function GeoeditorValidationServiceProvider() {
 
 angular.module('munimapGeoeditor')
     .provider('GeoeditorValidationService', GeoeditorValidationServiceProvider);
+

--- a/munimap/frontend/js/modules/colorpicker.js
+++ b/munimap/frontend/js/modules/colorpicker.js
@@ -1,6 +1,6 @@
-require('spectrum-colorpicker');
-require('angular-spectrum-colorpicker');
-require('angular-schema-form');
+import 'spectrum-colorpicker';
+import 'angular-spectrum-colorpicker';
+import 'angular-schema-form';
 
 angular.module('schemaForm').run(['$templateCache',
     function($templateCache) {

--- a/munimap/frontend/js/modules/confirm.js
+++ b/munimap/frontend/js/modules/confirm.js
@@ -1,6 +1,6 @@
 import 'bootstrap3/js/tooltip.js';
 import 'bootstrap3/js/popover.js';
-import './bootstrap-confirmation.js';
+require('./bootstrap-confirmation.js');
 
 angular.module('munimapBase.confirm', [])
 

--- a/munimap/frontend/js/modules/datepicker.js
+++ b/munimap/frontend/js/modules/datepicker.js
@@ -1,5 +1,5 @@
-require('angular-ui-bootstrap');
-require('angular-schema-form');
+import 'angular-ui-bootstrap';
+import 'angular-schema-form';
 
 angular.module('schemaForm').run(['$templateCache',
     function($templateCache) {

--- a/munimap/frontend/js/modules/plaintext.js
+++ b/munimap/frontend/js/modules/plaintext.js
@@ -1,5 +1,5 @@
-require('angular-ui-bootstrap');
-require('angular-schema-form');
+import 'angular-ui-bootstrap';
+import 'angular-schema-form';
 
 angular.module('schemaForm').run(['$templateCache', 
     function($templateCache) {

--- a/munimap/frontend/js/modules/slider-directive.js
+++ b/munimap/frontend/js/modules/slider-directive.js
@@ -1,13 +1,7 @@
-(function(factory) {
-    if (typeof define === 'function' && define.amd) {
-        define(['bootstrap-slider', 'angular'], factory);
-    } else if (typeof module === 'object' && module.exports) {
-        module.exports = factory(require('bootstrap-slider'), require('angular'));
-    } else if (window) {
-        factory(window.Slider);
-    }
-})(function (Slider) {
-    angular.module('ui.bootstrap-slider', [])
+import Slider from 'bootstrap-slider';
+import 'angular';
+
+angular.module('ui.bootstrap-slider', [])
         .directive('slider', ['$parse', '$timeout', '$rootScope', function ($parse, $timeout, $rootScope) {
             return {
                 restrict: 'AE',
@@ -226,4 +220,3 @@
                 }
             };
         }]);
-});

--- a/munimap/frontend/js/munimap-config.js
+++ b/munimap/frontend/js/munimap-config.js
@@ -1,4 +1,4 @@
-require('angular-ui-switch');
+import 'angular-ui-switch';
 
 import GeoJSON from 'ol/format/GeoJSON';
 

--- a/munimap/frontend/js/settings-modal-controller.js
+++ b/munimap/frontend/js/settings-modal-controller.js
@@ -1,4 +1,4 @@
-require('angular-ui-bootstrap');
+import 'angular-ui-bootstrap';
 
 angular.module('munimapBase')
     .controller('loadSettingsModalController', ['$scope', '$uibModalInstance',


### PR DESCRIPTION
Use ES6 `import` for external libraries (npm packages, anol, OpenLayers) while keeping `require()` for local Angular module files to preserve module load order.

ES6 imports are hoisted and execute before other code, which breaks Angular 1.x module registration that depends on sequential execution.

- Entry points (app.js, admin.js, static-app.js): import libraries, require local modules
- Module files (geoeditor-module.js, digitize-module.js): require sub-modules
- Library imports converted: angular-schema-form, angular-ui-bootstrap, ace-builds, etc.