### PR TITLE
Fix: permissions needed for semantic‑release

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -3,6 +3,9 @@ on:
   push:
     tags:
       - '*.*.*'
+  release:
+    types:
+      - published
 
 jobs:
   build-and-deploy:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,7 @@ jobs:
       packages: write
       id-token: write
       contents: write
+      pull-requests: write
 
     steps:
       - name: Install poetry


### PR DESCRIPTION
Added GitHub permissions needed for semantic‑release to comment on releases:

* In `.github/workflows/gh-pages.yml`, the workflow is now also triggered on release events of type published, in addition to tag pushes.
* In `.github/workflows/release.yml`, the build-and-deploy job permissions were expanded to include pull-requests: write, allowing the workflow (and `@semantic-release/github`) to write to pull requests, e.g. to add comments.


Plz review @TreffN @jansule 