### PR TITLE
Fix(mobile): layerswitcher issues

### DIFF
--- a/munimap/frontend/sass/components/sidebar.sass
+++ b/munimap/frontend/sass/components/sidebar.sass
@@ -84,6 +84,19 @@
           hr
             margin-top: 10px
 
+          @media screen and (max-width: media_queries.$screen-sm)
+
+            &::-webkit-scrollbar
+              width: 20px
+
+            &::-webkit-scrollbar-track
+              background: variables.$sidebar-item-highlight-color
+
+            &::-webkit-scrollbar-thumb
+              background-color: variables.$sidebar-text-color
+              border-radius: 5px
+              border: 2px solid variables.$sidebar-item-highlight-color
+
     .panel-default.panel-open
       .panel-heading
         background-color: variables.$sidebar-item-highlight-color

--- a/munimap/frontend/sass/components/sidebar.sass
+++ b/munimap/frontend/sass/components/sidebar.sass
@@ -159,6 +159,8 @@
           vertical-align: sub
 
         .layer-title
+          display: block
+          box-sizing: border-box
           cursor: pointer
 
         .layer-line

--- a/munimap/templates/munimap/app/ng-templates/layerswitcher-overlays.html
+++ b/munimap/templates/munimap/app/ng-templates/layerswitcher-overlays.html
@@ -90,6 +90,3 @@
       {$ _('No overlay layers available') $}
   </div>
 {% endif %}
-
-
-                


### PR DESCRIPTION
In particular:

* widen the scroll bar in the mobile panel
* widen clickable area to toggle layer visibility

TODO: Check, if `ui-sortable` directive should be moved to single layer (group) element, maybe also including a sort handler