### PR TITLE
feat: replace absolute-positioned controls with CSS flex column

### DIFF
--- a/dev/configs/munimap.conf
+++ b/dev/configs/munimap.conf
@@ -32,6 +32,7 @@ APP_CONFIG_DIR = data('app-configs')
 SELECTIONLISTS_CONFIG_DIR = data('selectionlists-configs')
 SITE_CONTENT_DIR = data('site-contents')
 PLUGINS_DIR = data('example-plugins')
+TOUR_DIR = data('tours')
 
 LAYERS_BASE_URL = 'http://localhost'
 

--- a/dev/data/app-configs/default-config.yaml
+++ b/dev/data/app-configs/default-config.yaml
@@ -5,6 +5,7 @@ app:
     showNoBackground: false
     showLogin: false
     hideMetadata: true
+    tour: 'test-tour'
     
 map:
     center:

--- a/dev/data/tours/test-tour.js
+++ b/dev/data/tours/test-tour.js
@@ -1,0 +1,15 @@
+angular.module('munimapBase').value('Tour', new Tour({
+    storage: window.localStorage,
+    steps: [
+        {
+            element: '.menu-control',
+            title: 'Menü',
+            content: 'Öffnet das Seitenmenü.'
+        },
+        {
+            element: '.tools-control',
+            title: 'Toolbox',
+            content: 'Werkzeuge \n Messen, Speichern/Laden, Passwort, Hilfe-Tour'
+        }
+    ]
+}));

--- a/munimap/frontend/js/alkis/selection.js
+++ b/munimap/frontend/js/alkis/selection.js
@@ -112,7 +112,7 @@ angular.module('munimapBase.alkisSelection', ['anol.map', 'ngStorage'])
                                 }
                             }).result.then(function(){}, function(){});
 
-                            var toolsControlContainerScope = angular.element('.tools-control-container').scope();
+                            var toolsControlContainerScope = angular.element('.tools-control').scope();
                             toolsControlContainerScope.toolsContainerVisible = false;
 
                             scope.deactivate();

--- a/munimap/frontend/js/base-controller.js
+++ b/munimap/frontend/js/base-controller.js
@@ -107,54 +107,21 @@ angular.module('munimapBase')
                 }
             }
 
-            // assign positions for mobile buttons
+            // assign positions for measure result and end-measure (not part of flex left column)
             if(angular.isDefined(munimapConfig.componentPositions) && angular.isDefined(munimapConfig.componentPositions.mobile)) {
-                $scope.mobileMenuButtonPosition = munimapConfig.componentPositions.mobile.menuButton || {};
-                $scope.mobileZoomButtonsPosition = munimapConfig.componentPositions.mobile.zoomButtons || {};
-                $scope.mobileGeolocationButtonPosition = munimapConfig.componentPositions.mobile.geolocationButton || {};
-                $scope.mobileHomeButtonPosition = munimapConfig.componentPositions.mobile.homeButton || {};
-                $scope.mobileRotationButtonPosition = munimapConfig.componentPositions.mobile.rotationButton || {};
-                $scope.mobileServiceButtonPosition = munimapConfig.componentPositions.mobile.serviceButton || {};
-                $scope.mobileServiceMenuPosition = munimapConfig.componentPositions.mobile.serviceMenu || {};
                 $scope.mobilePointMeasureResultPosition = munimapConfig.componentPositions.mobile.pointMeasureResult || {};
                 $scope.mobileEndMeasurePosition = munimapConfig.componentPositions.mobile.endMeasureButton || {};
-                $scope.mobileCustomControlsPositions = munimapConfig.componentPositions.mobile.customControls || [];
             } else {
-                $scope.mobileMenuButtonPosition = {};
-                $scope.mobileZoomButtonsPosition = {};
-                $scope.mobileGeolocationButtonPosition = {};
-                $scope.mobileHomeButtonPosition = {};
-                $scope.mobileRotationButtonPosition = {};
-                $scope.mobileServiceButtonPosition = {};
-                $scope.mobileServiceMenuPosition = {};
                 $scope.mobilePointMeasureResultPosition = {};
                 $scope.mobileEndMeasurePosition = {};
-                $scope.mobileCustomControlsPositions = [];
             }
 
-            // assign positions for desktop buttons
             if(angular.isDefined(munimapConfig.componentPositions) && angular.isDefined(munimapConfig.componentPositions.desktop)) {
-                $scope.desktopMenuButtonPosition = munimapConfig.componentPositions.desktop.menuButton || {};
-                $scope.desktopZoomButtonsPosition = munimapConfig.componentPositions.desktop.zoomButtons || {};
-                $scope.desktopGeolocationButtonPosition = munimapConfig.componentPositions.desktop.geolocationButton || {};
-                $scope.desktopHomeButtonPosition = munimapConfig.componentPositions.desktop.homeButton || {};
-                $scope.desktopRotationButtonPosition = munimapConfig.componentPositions.desktop.rotationButton || {};
-                $scope.desktopServiceButtonPosition = munimapConfig.componentPositions.desktop.serviceButton || {};
-                $scope.desktopServiceMenuPosition = munimapConfig.componentPositions.desktop.serviceMenu || {};
                 $scope.desktopPointMeasureResultPosition = munimapConfig.componentPositions.desktop.pointMeasureResult || {};
                 $scope.desktopEndMeasurePosition = munimapConfig.componentPositions.desktop.endMeasureButton || {};
-                $scope.desktopCustomControlsPositions = munimapConfig.componentPositions.desktop.customControls || [];
             } else {
-                $scope.desktopMenuButtonPosition = {};
-                $scope.desktopZoomButtonsPosition = {};
-                $scope.desktopGeolocationButtonPosition = {};
-                $scope.desktopHomeButtonPosition = {};
-                $scope.desktopRotationButtonPosition = {};
-                $scope.desktopServiceButtonPosition = {};
-                $scope.desktopServiceMenuPosition = {};
                 $scope.desktopPointMeasureResultPosition = {};
                 $scope.desktopEndMeasurePosition = {};
-                $scope.desktopCustomControlsPositions = [];
             }
 
             $scope.components = munimapConfig.components;
@@ -235,6 +202,22 @@ angular.module('munimapBase')
                 }
             };
 
+            $scope.zoomIn = function() {
+                const view = MapService.getMap().getView();
+                view.animate({
+                    zoom: view.getZoom() + 1,
+                    duration: 250
+                });
+            };
+
+            $scope.zoomOut = function() {
+                const view = MapService.getMap().getView();
+                view.animate({
+                    zoom: view.getZoom() - 1,
+                    duration: 250
+                });
+            };
+
             $scope.openCatalog = function() {
                 $uibModal.open({
                     windowClass: 'catalog-modal',
@@ -260,7 +243,7 @@ angular.module('munimapBase')
                     size: 'md',
                     controller: 'saveSettingsModalController'
                 }).result.then(function(){}, function(){});
-                var toolsControlContainerScope = angular.element('.tools-control-container').scope();
+                var toolsControlContainerScope = angular.element('.tools-control').scope();
                 toolsControlContainerScope.toggle();
             };
 
@@ -271,7 +254,7 @@ angular.module('munimapBase')
                     size: 'md',
                     controller: 'loadSettingsModalController'
                 }).result.then(function(){}, function(){});
-                var toolsControlContainerScope = angular.element('.tools-control-container').scope();
+                var toolsControlContainerScope = angular.element('.tools-control').scope();
                 toolsControlContainerScope.toggle();
             };
 
@@ -534,7 +517,7 @@ angular.module('munimapBase')
                 if(Tour === false) {
                     return;
                 }
-                var toolsControlContainerScope = angular.element('.tools-control-container').scope();
+                var toolsControlContainerScope = angular.element('.tools-control').scope();
                 toolsControlContainerScope.toggle();
                 Tour.restart();
             };
@@ -550,32 +533,44 @@ angular.module('munimapBase')
             });
 
             var initAdditionalMapElements = function() {
+                var wrapper = angular.element('.left-controls-wrapper');
+
+                // Register wrapper as OL control → moves wrapper (with its children)
+                // into .ol-overlaycontainer-stopevent
+                var wrapperControl = new anol.control.Control({ element: wrapper });
+                ControlsService.addControl(wrapperControl);
+
+                // Register menu and home controls with target → appended into wrapper
                 var menuControlElement = angular.element('.menu-control');
                 if(menuControlElement.length > 0) {
-                    var menuControl = new anol.control.Control({
-                        element: menuControlElement
-                    });
-                    ControlsService.addControl(menuControl);
+                    ControlsService.addControl(new anol.control.Control({
+                        element: menuControlElement,
+                        target: wrapper
+                    }));
                 }
                 var homeControlElement = angular.element('.home-control');
                 if(homeControlElement.length > 0) {
-                    var homeControl = new anol.control.Control({
-                        element: homeControlElement
-                    });
-                    ControlsService.addControl(homeControl);
+                    ControlsService.addControl(new anol.control.Control({
+                        element: homeControlElement,
+                        target: wrapper
+                    }));
                 }
-                var toolsControlElement = angular.element('.tools-control');
-                var toolsContainerControlElement = angular.element('.tools-container-control');
-                if(toolsControlElement.length > 0 && toolsContainerControlElement.length > 0) {
-                    var toolsControl = new anol.control.Control({
-                        element: toolsControlElement
-                    });
-                    ControlsService.addControl(toolsControl);
-                    var toolsContainerControl = new anol.control.Control({
-                        element: toolsContainerControlElement
-                    });
-                    ControlsService.addControl(toolsContainerControl);
-                }
+
+                // anol-geolocation and anol-rotation register without a target, so OL places
+                // them in the overlay container during ControlsService.registerMap().
+                // registerMap fires in a $timeout queued BEFORE this function runs,
+                // so it fires AFTER this function. A nested $timeout here fires AFTER
+                // registerMap, letting us move those elements into the wrapper safely.
+                $timeout(function() {
+                    var geolocationEl = angular.element('.anol-geolocation');
+                    if(geolocationEl.length > 0) {
+                        wrapper.append(geolocationEl);
+                    }
+                    var rotationEl = angular.element('.ol-rotate');
+                    if(rotationEl.length > 0) {
+                        wrapper.append(rotationEl);
+                    }
+                });
 
                 /** if we don´t add this as control the eventPropagation is no longer handled by openlayers.
                 * so we can rightclick on this element to get the default contextmenu. this is useful to copy the coordinates.

--- a/munimap/frontend/js/base-controller.js
+++ b/munimap/frontend/js/base-controller.js
@@ -243,8 +243,7 @@ angular.module('munimapBase')
                     size: 'md',
                     controller: 'saveSettingsModalController'
                 }).result.then(function(){}, function(){});
-                var toolsControlContainerScope = angular.element('.tools-control').scope();
-                toolsControlContainerScope.toggle();
+                $scope.toggleToolsContainer && $scope.toggleToolsContainer();
             };
 
             $scope.openLoadSettingsModal = function() {
@@ -254,8 +253,7 @@ angular.module('munimapBase')
                     size: 'md',
                     controller: 'loadSettingsModalController'
                 }).result.then(function(){}, function(){});
-                var toolsControlContainerScope = angular.element('.tools-control').scope();
-                toolsControlContainerScope.toggle();
+                $scope.toggleToolsContainer && $scope.toggleToolsContainer();
             };
 
             $scope.transparencyDialogOpen = TransparencyDialogService.isOpen();
@@ -517,8 +515,7 @@ angular.module('munimapBase')
                 if(Tour === false) {
                     return;
                 }
-                var toolsControlContainerScope = angular.element('.tools-control').scope();
-                toolsControlContainerScope.toggle();
+                $scope.toggleToolsContainer && $scope.toggleToolsContainer();
                 Tour.restart();
             };
 

--- a/munimap/frontend/js/base-controller.js
+++ b/munimap/frontend/js/base-controller.js
@@ -558,10 +558,9 @@ angular.module('munimapBase')
 
                 // anol-geolocation and anol-rotation register without a target, so OL places
                 // them in the overlay container during ControlsService.registerMap().
-                // registerMap fires in a $timeout queued BEFORE this function runs,
-                // so it fires AFTER this function. A nested $timeout here fires AFTER
-                // registerMap, letting us move those elements into the wrapper safely.
-                $timeout(function() {
+                // Wait for registerMap to complete before moving them into the wrapper.
+                var deregister = $rootScope.$on('anol.controls.registered', function() {
+                    deregister();
                     var geolocationEl = angular.element('.anol-geolocation');
                     if(geolocationEl.length > 0) {
                         wrapper.append(geolocationEl);

--- a/munimap/frontend/js/modules/alkisbutton.js
+++ b/munimap/frontend/js/modules/alkisbutton.js
@@ -6,31 +6,29 @@ angular.module('munimapBase.alkisButton', ['anol.map'])
             transclude: true,
             replace: false,
             link: function(scope, element, attributes) {
-                scope.ngStyle = scope.$eval(attributes.ngStyle);
-                scope.menuStyle = scope.$eval(attributes.menuStyle);
+                scope.alkisContainerVisible = false;
+
+                var alkisControl = new anol.control.Control({
+                    element: element.find('.alkis-control'),
+                    exclusive: true,
+                    target: angular.element('.left-controls-wrapper')
+                });
+
+                alkisControl.onDeactivate(function() {
+                    scope.alkisContainerVisible = false;
+                    scope.$apply();
+                });
 
                 scope.toggle = function() {
-                    if (alkisContainerControl.active) {
-                        alkisContainerControl.deactivate();
-                        // toggle alkis control to deactiave all other controls
+                    if (scope.alkisContainerVisible) {
+                        scope.alkisContainerVisible = false;
                         alkisControl.activate();
                         alkisControl.deactivate();
                     } else {
-                        alkisContainerControl.activate();                         
+                        scope.alkisContainerVisible = true;
                     }
                 };
-                // button on openlayers
-                var alkisControl = new anol.control.Control({
-                    element: element.find('.alkis-control'),
-                    exclusive: true
-                });
-                // container from the button - menu to toggle menus
-                var alkisContainerControl = new anol.control.Control({
-                    element: element.find('.alkis-container-control'),
-                    menu: true
-                });
 
-                ControlsService.addControl(alkisContainerControl);
                 ControlsService.addControl(alkisControl);
             }
         };

--- a/munimap/frontend/js/modules/alkisbutton.js
+++ b/munimap/frontend/js/modules/alkisbutton.js
@@ -16,7 +16,7 @@ angular.module('munimapBase.alkisButton', ['anol.map'])
 
                 alkisControl.onDeactivate(function() {
                     scope.alkisContainerVisible = false;
-                    scope.$apply();
+                    scope.$applyAsync();
                 });
 
                 scope.toggle = function() {

--- a/munimap/frontend/js/modules/customcontrol.js
+++ b/munimap/frontend/js/modules/customcontrol.js
@@ -12,8 +12,6 @@ angular.module('munimapBase.customControl', ['anol.map'])
                 'controlShowTooltip': '='
             },
             link: function(scope, element, attributes) {
-                scope.ngStyle = scope.$eval(attributes.ngStyle);
-
                 scope.click = function() {
                     const callback = $window.customControlPlugins[scope.controlCallback];
                     if (!callback) {
@@ -24,7 +22,8 @@ angular.module('munimapBase.customControl', ['anol.map'])
                 // button on openlayers
                 var customControl = new anol.control.Control({
                     element: element.find('.custom-control'),
-                    exclusive: false
+                    exclusive: false,
+                    target: angular.element('.left-controls-wrapper')
                 });
 
                 ControlsService.addControl(customControl);

--- a/munimap/frontend/js/modules/servicebutton.js
+++ b/munimap/frontend/js/modules/servicebutton.js
@@ -4,39 +4,35 @@ angular.module('munimapBase.servicebutton', ['anol.map'])
         return {
             templateUrl: 'munimap/servicebutton.html',
             transclude: true,
-            replace: true,
+            replace: false,
             link: function(scope, element, attributes) {
-                scope.ngStyle = scope.$eval(attributes.ngStyle);
-                scope.menuStyle = scope.$eval(attributes.menuStyle);
                 scope.toolsContainerVisible = false;
 
                 scope.hideToolsContainer = function() {
                     scope.toolsContainerVisible = false;
                 };
 
+                var toolsControl = new anol.control.Control({
+                    element: element.find('.tools-control'),
+                    exclusive: true,
+                    target: angular.element('.left-controls-wrapper')
+                });
+
+                toolsControl.onDeactivate(function() {
+                    scope.toolsContainerVisible = false;
+                    scope.$apply();
+                });
+
                 scope.toggle = function() {
-                    if (toolsContainerControl.active) {
-                        toolsContainerControl.deactivate(); 
-                        // toggle alkis control to deactiave all other controls
+                    if (scope.toolsContainerVisible) {
+                        scope.toolsContainerVisible = false;
                         toolsControl.activate();
                         toolsControl.deactivate();
                     } else {
-                        toolsContainerControl.activate();        
+                        scope.toolsContainerVisible = true;
                     }
                 };
-                // button on openlayers
-                var toolsControl = new anol.control.Control({
-                    element: element.find('.tools-control'),
-                    exclusive: true
-                });
 
-                // container from the button - menu to toggle menus
-                var toolsContainerControl = new anol.control.Control({
-                    element: element.find('.tools-container-control'),
-                    menu: true
-                });
-
-                ControlsService.addControl(toolsContainerControl);
                 ControlsService.addControl(toolsControl);
             }
         };

--- a/munimap/frontend/js/modules/servicebutton.js
+++ b/munimap/frontend/js/modules/servicebutton.js
@@ -20,7 +20,7 @@ angular.module('munimapBase.servicebutton', ['anol.map'])
 
                 toolsControl.onDeactivate(function() {
                     scope.toolsContainerVisible = false;
-                    scope.$apply();
+                    scope.$applyAsync();
                 });
 
                 scope.toggle = function() {

--- a/munimap/frontend/js/modules/servicebutton.js
+++ b/munimap/frontend/js/modules/servicebutton.js
@@ -23,7 +23,7 @@ angular.module('munimapBase.servicebutton', ['anol.map'])
                     scope.$applyAsync();
                 });
 
-                scope.toggle = function() {
+                scope.toggleToolsContainer = function() {
                     if (scope.toolsContainerVisible) {
                         scope.toolsContainerVisible = false;
                         toolsControl.activate();

--- a/munimap/frontend/sass/components/map.sass
+++ b/munimap/frontend/sass/components/map.sass
@@ -177,7 +177,8 @@
         color: variables.$map-button-color
 
 /*
- * Map button positions
+ * Map button fallback positions (used by non-flex map templates, e.g. transport map)
+ * These are overridden inside .left-controls-wrapper by position: relative / top: auto
  */
 .menu-control
   top: 0.5em
@@ -226,9 +227,75 @@
   left: 3.5em
 
 .custom-control
-  z-index: 3
   top: 14.5em
   left: 0.5em
+
+.ol-rotate
+  top: 12.5em
+  left: 0.5em
+  right: inherit
+
+/* Left controls flex column */
+.left-controls-wrapper
+  position: absolute
+  top: 0.5em
+  left: 0.5em
+  display: flex
+  flex-direction: column
+  align-items: flex-start
+  gap: 0.1em
+  pointer-events: none
+
+  // Override OL's absolute positioning for flex items
+  .ol-control
+    position: relative
+    left: auto
+    right: auto
+    top: auto
+    pointer-events: auto
+
+  // Dropdown menus: positioned right of their button (taken out of flex flow)
+  .tools-container-control,
+  .alkis-container-control
+    position: absolute
+    left: 100%
+    top: 0
+    background-color: white
+    border-radius: 0
+    padding: 0
+    border: 1px solid #adadad
+    z-index: 3
+    &:hover
+      background-color: white
+    .list-group-item
+      border: 0
+      &.active
+        background-color: #337ab7
+        color: white
+        opacity: 0.8
+        border-radius: 0
+        font-weight: 600
+
+  // Flex order — enforces visual ordering regardless of DOM append order
+  .menu-control
+    order: 1
+  .zoom-control
+    order: 2
+  .anol-geolocation
+    order: 3
+  .home-control
+    order: 4
+  .tools-control
+    order: 5
+  .alkis-control
+    order: 6
+  .custom-control
+    order: 7
+  .ol-rotate
+    order: 8
+
+.custom-control
+  z-index: 3
 
   span
     color: #fff
@@ -276,44 +343,6 @@
   background: white
   padding: 4px
   border-radius: 4px
-
-.ol-rotate
-  top: 12.5em
-  left: 0.5em
-  right: inherit
-
-.ol-touch
-  .ol-zoom
-    top: 3.2em
-
-  .anol-geolocation
-    top: 8.1em
-
-  .home-control
-    top: 10.6em
-
-  .tools-control
-    top: 13.1em
-
-  .tools-container-control
-    top: 13.1em
-
-  .alkis-control
-    top: 15.6em
-    .glyphicon
-      line-height: 1em
-
-  .timetable-control
-    top: 15.6em !important
-
-  .alkis-container-control
-    top: 15.6em
-
-  .ol-rotate
-    top: 18.1em
-
-  .custom-control
-    top: 20.6em
 
 /*
  * Popup Styling

--- a/munimap/templates/munimap/app/map.html
+++ b/munimap/templates/munimap/app/map.html
@@ -36,6 +36,22 @@
     </div>
 </div>
 <div anol-map class="map" style="position: relative;">
+  <div class="left-controls-wrapper">
+    <div class="ol-control zoom-control">
+      <button ng-click="zoomIn()"
+              uib-tooltip="{{ 'anol.zoom.TOOLTIP_ZOOM_IN' | translate }}"
+              tooltip-placement="right" tooltip-popup-delay="{{ tooltipDelay }}"
+              tooltip-trigger="mouseenter" tooltip-enable="showTooltip">
+        <span class="glyphicon glyphicon-plus"></span>
+      </button>
+      <button ng-click="zoomOut()"
+              uib-tooltip="{{ 'anol.zoom.TOOLTIP_ZOOM_OUT' | translate }}"
+              tooltip-placement="right" tooltip-popup-delay="{{ tooltipDelay }}"
+              tooltip-trigger="mouseenter" tooltip-enable="showTooltip">
+        <span class="glyphicon glyphicon-minus"></span>
+      </button>
+    </div>
+  </div>
   <div anol-url-markers></div>
   <div anol-attribution
        tooltip-delay="{{ tooltipDelay}}">
@@ -43,12 +59,7 @@
   {% include 'munimap/app/draw-popup.html' %}
   {% include 'munimap/app/geoeditor-popup.html' %}
   {% include 'munimap/app/digitize-popup.html' %}
-  <div anol-zoom
-       ng-style="hasTouch ? mobileZoomButtonsPosition : desktopZoomButtonsPosition"
-       tooltip-delay="{{ tooltipDelay}}">
-  </div>
   <div anol-rotation
-       ng-style="hasTouch ? mobileRotationButtonPosition : desktopRotationButtonPosition"
        tooltip-delay="{{ tooltipDelay }}">
   </div>
 
@@ -86,7 +97,6 @@
   {% endif %}
 
   <div ng-if="geolocationEnabled"
-       ng-style="hasTouch ? mobileGeolocationButtonPosition : desktopGeolocationButtonPosition"
        anol-geolocation="{{geolocationConfig.tracking}}"
        highlight="{{geolocationConfig.resultVisible}}"
        result-style="{
@@ -113,7 +123,6 @@
        ng-if="scaleLineEnabled">
   </div>
   <div ng-if="menuButtonEnabled"
-       ng-style="hasTouch ? mobileMenuButtonPosition : desktopMenuButtonPosition"
        class="ol-control menu-control">
     <button ng-click="toggleMenu()"
             uib-tooltip="{{ sidebar.open ? '{$ _('Close menu') $}' : '{$ _('Open menu') $}' }}"
@@ -125,7 +134,6 @@
     </button>
   </div>
   <div ng-if="homeButtonEnabled"
-       ng-style="hasTouch ? mobileHomeButtonPosition : desktopHomeButtonPosition"
        class="ol-control home-control">
     <button ng-click="goHome()"
             uib-tooltip="{$ _('Startposition') $}"
@@ -137,8 +145,6 @@
     </button>
   </div>
   <service-button ng-if="serviceButtonEnabled"
-                  ng-style="hasTouch ? mobileServiceButtonPosition : desktopServiceButtonPosition"
-                  menu-style="hasTouch ? mobileServiceMenuPosition : desktopServiceMenuPosition"
                   >
     <a anol-measure="point"
        geodesic="false"
@@ -196,8 +202,7 @@
     </a>
   </service-button>
   <alkis-button ng-if="alkisButtonEnabled"
-      ng-style="hasTouch ? mobileServiceButtonPosition : desktopServiceButtonPosition"
-      menu-style="hasTouch ? mobileServiceMenuPosition : desktopServiceMenuPosition">
+      >
 
     {% if app_config.get('components').get('alkis') and  app_config.get('components').get('alkis').get('simple') %}
     <a alkis-simple
@@ -285,7 +290,6 @@
   {% if app_config.get('components', []).get('customControls') %}
     {% for customControl in app_config['components']['customControls'] %}
       <custom-control
-           ng-style="hasTouch ? mobileCustomControlsPositions[{$ loop.index0 $}] : desktopCustomControlsPositions[{$ loop.index0 $}]"
            control-text="{$ customControl.get('text') $}"
            control-title="{$ customControl.get('title') $}"
            control-callback="{$ customControl.get('callback') $}"

--- a/munimap/templates/munimap/app/map.html
+++ b/munimap/templates/munimap/app/map.html
@@ -201,8 +201,7 @@
       Hilfe starten
     </a>
   </service-button>
-  <alkis-button ng-if="alkisButtonEnabled"
-      >
+  <alkis-button ng-if="alkisButtonEnabled">
 
     {% if app_config.get('components').get('alkis') and  app_config.get('components').get('alkis').get('simple') %}
     <a alkis-simple

--- a/munimap/templates/munimap/app/ng-templates/alkisbutton.html
+++ b/munimap/templates/munimap/app/ng-templates/alkisbutton.html
@@ -1,16 +1,13 @@
-<div class="alkis-control-container">
-  <div class="ol-control alkis-control" ng-style="ngStyle">
-    <button ng-click="toggle()"
-            uib-tooltip="{$ _('Alkis Tools') $}"
-            tooltip-placement="right"
-            tooltip-popup-delay="{{tooltipDelay}}"
-            tooltip-trigger="mouseenter"
-            tooltip-enable="showTooltip">
-      <span class="glyphicon alkis-icon"></span>
-    </button>
-  </div>
-  <div class="ol-control alkis-container-control list-group"
-       ng-style="menuStyle">
+<div class="ol-control alkis-control">
+  <button ng-click="toggle()"
+          uib-tooltip="{$ _('Alkis Tools') $}"
+          tooltip-placement="right"
+          tooltip-popup-delay="{{tooltipDelay}}"
+          tooltip-trigger="mouseenter"
+          tooltip-enable="showTooltip">
+    <span class="glyphicon alkis-icon"></span>
+  </button>
+  <div class="alkis-container-control list-group" ng-show="alkisContainerVisible">
     <ng-transclude></ng-transclude>
   </div>
 </div>

--- a/munimap/templates/munimap/app/ng-templates/servicebutton.html
+++ b/munimap/templates/munimap/app/ng-templates/servicebutton.html
@@ -1,20 +1,13 @@
-<div class="tools-control-container">
-  <div class="ol-control tools-control" ng-style="ngStyle">
-    <button ng-click="toggle()"
-            uib-tooltip="{$ _('Tools') $}"
-            tooltip-placement="right"
-            tooltip-popup-delay="{{tooltipDelay}}"
-            tooltip-trigger="mouseenter"
-            tooltip-enable="showTooltip">
-      <span class="glyphicon glyphicon-wrench"></span>
-    </button>
-  </div>
-  <div class="ol-control tools-container-control list-group"
-       ng-style="menuStyle">
+<div class="ol-control tools-control">
+  <button ng-click="toggle()"
+          uib-tooltip="{$ _('Tools') $}"
+          tooltip-placement="right"
+          tooltip-popup-delay="{{tooltipDelay}}"
+          tooltip-trigger="mouseenter"
+          tooltip-enable="showTooltip">
+    <span class="glyphicon glyphicon-wrench"></span>
+  </button>
+  <div class="tools-container-control list-group" ng-show="toolsContainerVisible">
     <ng-transclude></ng-transclude>
   </div>
 </div>
-
-
-
-

--- a/munimap/templates/munimap/app/ng-templates/servicebutton.html
+++ b/munimap/templates/munimap/app/ng-templates/servicebutton.html
@@ -1,5 +1,5 @@
 <div class="ol-control tools-control">
-  <button ng-click="toggle()"
+  <button ng-click="toggleToolsContainer()"
           uib-tooltip="{$ _('Tools') $}"
           tooltip-placement="right"
           tooltip-popup-delay="{{tooltipDelay}}"


### PR DESCRIPTION
All left-column map controls (zoom, geolocation, menu, home, tools, alkis, custom, rotation) are now children of a single `.left-controls-wrapper` flex container, eliminating hardcoded `top:` values and the gaps they left when optional controls were disabled.

- Add `.left-controls-wrapper` with custom zoom buttons to map.html, replacing `anol-zoom`
- Register the wrapper as an OL control in `initAdditionalMapElements`; geolocation/rotation are moved into it via a nested `$timeout` (fires after `ControlsService.registerMap` so OL does not undo the move)
- Register service-button, alkis-button and custom-control with `target: .left-controls-wrapper` so OL places them inside the wrapper
- Collapse the outer `.tools-control-container` / `.alkis-control-container` wrappers; dropdowns now live inside their button element and are shown via `ng-show` + `onDeactivate` callback instead of the menu-control mechanism
- Remove per-control `componentPositions` scope variables (mobile/desktop position overrides); keep only the measure-result and end-measure ones
- Add `zoomIn()` / `zoomOut()` scope methods using `view.animate()`
- Replace SASS absolute-position block with flex-column rules and `order` properties; keep fallback absolute positions for the transport map