### PR TITLE
chore(PostGIS): upgrade database to version postgis:18-3.6

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,9 +1,11 @@
+x-munimap-db-image: &munimap-db-image docker.terrestris.de/postgis/postgis:18-3.6-alpine
+
 services:
   munimap-nginx:
     image: docker.terrestris.de/library/nginx:1.27.1-alpine
     ports:
-      - 80:80
-      - 4000:4000
+      - "80:80"
+      - "4000:4000"
     volumes:
       - ./munimap-nginx/favicon.ico:/opt/etc/munimap/favicon.ico
       - ./munimap-nginx/default.conf:/etc/nginx/conf.d/default.conf
@@ -17,8 +19,8 @@ services:
   munimap-nginx-dev:
     image: docker.terrestris.de/library/nginx:1.27.1-alpine
     ports:
-      - 80:80
-      - 4000:4000
+      - "80:80"
+      - "4000:4000"
     volumes:
       - ./munimap-nginx/favicon.ico:/opt/etc/munimap/favicon.ico
       - ./munimap-nginx/default-dev.conf:/etc/nginx/conf.d/default.conf
@@ -72,15 +74,15 @@ services:
       - prod
 
   munimap-postgis:
-    image: docker.terrestris.de/postgis/postgis:9.6-2.5-alpine
+    image: *munimap-db-image
     ports:
-      - 5555:5432
+      - "5555:5432"
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
     volumes:
       - ./munimap-postgis/postgresql_init_data:/docker-entrypoint-initdb.d
-      - ./munimap-postgis/postgresql_data:/var/lib/postgresql/data:Z
+      - ./munimap-postgis/postgresql_data:/var/lib/postgresql/:Z
     healthcheck:
       test: [ "CMD-SHELL", "pg_isready -U postgres -d stadtplan"]
       interval: 10s
@@ -88,15 +90,15 @@ services:
       retries: 10
 
   munimap-postgis-mapbender:
-    image: docker.terrestris.de/postgis/postgis:10-2.5-alpine
+    image: *munimap-db-image
     ports:
-      - 5556:5432
+      - "5556:5432"
     environment:
       POSTGRES_USER: mapbender
       POSTGRES_PASSWORD: mapbender
     volumes:
       - ./munimap-postgis-mapbender/postgresql_init_data:/docker-entrypoint-initdb.d
-      - ./munimap-postgis-mapbender/postgresql_data:/var/lib/postgresql/data:Z
+      - ./munimap-postgis-mapbender/postgresql_data:/var/lib/postgresql/:Z
     profiles:
       - dev
       - prod
@@ -110,7 +112,7 @@ services:
     restart: unless-stopped
     image: docker.terrestris.de/camptocamp/mapfish_print:3.30.11
     ports:
-      - 8888:8080
+      - "8888:8080"
     environment:
       # Because of failing DIN A0 prints in production, the heap size needed to be increased to 4gb
       JAVA_OPTS: -Xmx4096m -Djava.awt.headless=true


### PR DESCRIPTION
BREAKING CHANGE: Bump postgres to version 18 and Postgis to v3.6

In this PR the dabatase image of `munimap-postgis` and `munimap-postgis-mapbender` are updated to a common version `docker.terrestris.de/postgis/postgis:18-3.6-alpine`

