### PR TITLE
feat: allow configuring the maengelmelder

### DIFF
--- a/munimap/config.py
+++ b/munimap/config.py
@@ -151,7 +151,14 @@ class DefaultConfig(object):
     TIMETABLE_STOPFINDER_PRIORITIES = ['bielefeld', 'bi-']
     TIMETABLE_TRIP_API = '/nwlsl3+/trip?lng=de&sharedLink=true'
 
-    TIMETABLE_DEFAULT_CTIY = 'Bielefeld'
+    # True, if the Mängelmelder Button should be shown, false otherwise
+    MAENGELMELDER_VISIBLE = True
+    # The url to the Mängelmelder
+    MAENGELMELDER_URL = 'https://beteiligung.nrw.de/portal/bielefeld/beteiligung/themen/1001101'
+    # The text of the button
+    MAENGELMELDER_TEXT = 'Mängelmelder BI'
+    # The title of the button
+    MAENGELMELDER_TITLE = 'Aufruf des Bielefelder Mängelmelders'
 
     TIMETABLE_DOCUMENTS_CSV = False
     TIMETABLE_DOCUMENTS_BASE_URL = ''

--- a/munimap/templates/munimap/app/map.html
+++ b/munimap/templates/munimap/app/map.html
@@ -172,10 +172,10 @@
        deactivated-callback="$parent.$parent.onAreaMeasureDeactivated"
        activated-callback="$parent.$parent.onAreaMeasureActivated">
     </a>
-    {% if base_config.get("TIMETABLE_DEFAULT_CTIY") == 'Bielefeld' %}
-    <a href="https://beteiligung.nrw.de/portal/bielefeld/beteiligung/themen/1001101" title="Aufruf des Bielefelder Mängelmelders"
+    {% if base_config.get("MAENGELMELDER_VISIBLE") %}
+    <a href="{$ base_config.get('MAENGELMELDER_URL') $}" title="{$ base_config.get('MAENGELMELDER_TITLE') $}"
       target="_blank" class="list-group-item">
-      Mängelmelder BI
+      {$ base_config.get('MAENGELMELDER_TEXT') $}
     </a>
     {% endif %}
     {% if not current_user.is_anonymous %}


### PR DESCRIPTION
BREAKING CHANGE: The previously used config option TIMETABLE_DEFAULT_CTIY was deprecated and can be removed from any configuration. Instead use MAENGELMELDER_VISIBLE, MAENGELMELDER_URL, MAENGELMELDER_TITLE, MAENGELMELDER_TEXT.