### PR TITLE
fix: use webhook event `workflow_run` for documentation update

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,14 +1,14 @@
 name: Deploy Documentation to Github Pages
 on:
-  push:
-    tags:
-      - '*.*.*'
-  release:
+  workflow_run:
+    workflows:
+      - Release
     types:
-      - published
+      - completed
 
 jobs:
   build-and-deploy:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -17,11 +17,13 @@ jobs:
     steps:
       - name: Checkout 🛎️
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
-      - name: Extract version from tag
+      - name: Extract version from latest tag
         id: version
         run: |
-          VERSION=${GITHUB_REF#refs/tags/}
+          VERSION=$(git describe --tags --abbrev=0)
           echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
           echo "Extracted version: $VERSION"
 

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ node_modules
 *.code-workspace
 /docker/munimap-mapproxy/mapproxy_cache_data/
 /munimap/static/
+*.iml


### PR DESCRIPTION
Since the publication workflow of the documentation is not triggered via `tag` push, we might use [`workflow_run`](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#workflow_run) in combination with a check of successful run (see also [here](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#running-a-workflow-based-on-the-conclusion-of-another-workflow))

Plz review @jansule 