### PR TITLE
fix: resolve sortablejs via anol's installed node_modules

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -45,7 +45,7 @@ module.exports  = {
         'bootstrap': path.resolve('./node_modules/bootstrap'),
         'angular-ui-bootstrap': path.resolve('./node_modules/angular-ui-bootstrap'),
         'jquery': path.resolve('./node_modules/jquery/src/jquery'),
-        'sortablejs': path.resolve('../anol/node_modules/sortablejs/Sortable.js')
+        'sortablejs': path.resolve('./node_modules/anol/node_modules/sortablejs/Sortable.js')
       }
     },
     module: {


### PR DESCRIPTION
Fixes layer drag & drop sorting broken in deployed environments. The previous alias used ../anol/node_modules/sortablejs/Sortable.js (a sibling path that only exists locally), replaced with ./node_modules/anol/node_modules/sortablejs/Sortable.js which works wherever anol is installed as an npm dependency.