### PR TITLE
fix: revert "fix: documentation link"

### DIFF
--- a/munimap/views/frontend.py
+++ b/munimap/views/frontend.py
@@ -20,8 +20,7 @@ def pages(name):
     try:
         app_version = importlib.metadata.version('munimap')
         release_link = f'https://github.com/stadt-bielefeld/bielefeldGEOCLIENT/releases/tag/{app_version}'
-        documentation_link = f'https://stadt-bielefeld.github.io/bielefeldGEOCLIENT/latest/'
-
+        documentation_link = f'https://stadt-bielefeld.github.io/bielefeldGEOCLIENT/{app_version}/index.html'
         site_content = current_app.site_contents.get(name)
 
         return render_template(


### PR DESCRIPTION
This reverts commit 8b4ff99a1f58b77225fe2f7b0d6fa932a6d58c39, in order to point to the documentation that matches the actually deployed version instead of latest.