### PR TITLE
fix(styles): hide focus ring on mouse-clicked metadata links

### DIFF
--- a/munimap/frontend/sass/components/general.sass
+++ b/munimap/frontend/sass/components/general.sass
@@ -66,6 +66,10 @@ iframe
   &:first-child
     padding-top: 0
 
+.overlay-layerswitcher, .anol-catalog
+  a:focus:not(:focus-visible)
+    outline: none
+
 .notifications
   position: absolute
   top: 5px


### PR DESCRIPTION
Bootstrap 3 sets an outline on every a:focus. The metadata links (info-i's in the layerswitcher) open in a new tab, so the anchor keeps focus when the user returns and the ring stayed visible until something else was clicked.

Scoping the reset to :focus-visible drops the ring for pointer input while keeping it for keyboard navigation, where it is the only indicator of which link is active.